### PR TITLE
fix(ci): add missing admin schema migration

### DIFF
--- a/src/main/resources/db/migration/V9__add_admin_visibility_and_member_status.sql
+++ b/src/main/resources/db/migration/V9__add_admin_visibility_and_member_status.sql
@@ -1,6 +1,7 @@
 ALTER TABLE member
     ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE' AFTER student_number_visible,
-    ADD COLUMN suspended_until DATETIME(6) NULL AFTER status;
+    ADD COLUMN suspended_until DATETIME(6) NULL AFTER status,
+    ADD INDEX idx_member_status_id (status, id DESC);
 
 ALTER TABLE post
     ADD COLUMN hidden_by_admin TINYINT(1) NOT NULL DEFAULT 0 AFTER view_count;

--- a/src/test/java/kr/ac/knu/comit/global/persistence/FlywayMigrationIntegrationTest.java
+++ b/src/test/java/kr/ac/knu/comit/global/persistence/FlywayMigrationIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         classes = ComitApplication.class,
         properties = {
                 "SPRING_PORT=0",
+                "DDL_AUTO=none",
                 "MAX_FILE_SIZE=10MB",
                 "MAX_REQUEST_SIZE=10MB",
                 "COMIT_AUTH_BRIDGE_ENABLED=false"
@@ -91,7 +92,7 @@ class FlywayMigrationIntegrationTest {
         // then
         // Flyway 이력 테이블과 핵심 도메인 테이블이 모두 생성되어야 한다.
         assertThat(historyTableCount).isEqualTo(1);
-        assertThat(appliedMigrationCount).isEqualTo(9);
+        assertThat(appliedMigrationCount).isEqualTo(10);
         assertThat(tables).contains(
                 "flyway_schema_history",
                 "member",

--- a/src/test/java/kr/ac/knu/comit/post/domain/PostRepositoryIntegrationTest.java
+++ b/src/test/java/kr/ac/knu/comit/post/domain/PostRepositoryIntegrationTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         classes = ComitApplication.class,
         properties = {
                 "SPRING_PORT=0",
+                "DDL_AUTO=none",
                 "MAX_FILE_SIZE=10MB",
                 "MAX_REQUEST_SIZE=10MB"
         }


### PR DESCRIPTION
## 개요
- PR #14에서 엔티티에 추가된 관리자 관련 컬럼의 Flyway 마이그레이션을 보강합니다.
- CI에서 `PostRepositoryIntegrationTest`가 실패하던 원인을 스키마 정합성으로 복구합니다.

## 주요 변경
- `member.status`, `member.suspended_until` 컬럼 추가
- `post.hidden_by_admin`, `comment.hidden_by_admin` 컬럼 추가
- Flyway 회귀 테스트를 9개 마이그레이션 기준으로 갱신

## 검증
- `./gradlew test --tests kr.ac.knu.comit.global.persistence.FlywayMigrationIntegrationTest --tests kr.ac.knu.comit.post.domain.PostRepositoryIntegrationTest`
- `./gradlew test`

## Related
- restores main CI after #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Member accounts now support status tracking with suspension management and end-date capabilities
  * Administrators can hide individual posts and comments from public visibility
  * Database optimizations implemented to improve performance of member status queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->