### PR TITLE
fix(test): unblock main CI after admin schema changes

### DIFF
--- a/src/test/java/kr/ac/knu/comit/global/persistence/FlywayMigrationIntegrationTest.java
+++ b/src/test/java/kr/ac/knu/comit/global/persistence/FlywayMigrationIntegrationTest.java
@@ -92,7 +92,7 @@ class FlywayMigrationIntegrationTest {
         // then
         // Flyway 이력 테이블과 핵심 도메인 테이블이 모두 생성되어야 한다.
         assertThat(historyTableCount).isEqualTo(1);
-        assertThat(appliedMigrationCount).isEqualTo(10);
+        assertThat(appliedMigrationCount).isEqualTo(9);
         assertThat(tables).contains(
                 "flyway_schema_history",
                 "member",

--- a/src/test/java/kr/ac/knu/comit/post/domain/PostRepositoryIntegrationTest.java
+++ b/src/test/java/kr/ac/knu/comit/post/domain/PostRepositoryIntegrationTest.java
@@ -179,11 +179,22 @@ class PostRepositoryIntegrationTest {
     }
 
     private Member saveMember(String suffix) {
+        String nickname = buildValidNickname(suffix);
+        String studentNumber = buildStudentNumber(suffix);
         return memberRepository.save(Member.create(
                 "sso-" + suffix,
-                "nickname-" + suffix,
-                "202300" + Math.abs(suffix.hashCode() % 100)
+                nickname,
+                studentNumber
         ));
+    }
+
+    private String buildValidNickname(String suffix) {
+        String candidate = "n" + Integer.toUnsignedString(suffix.hashCode(), 36);
+        return candidate.length() > 15 ? candidate.substring(0, 15) : candidate;
+    }
+
+    private String buildStudentNumber(String suffix) {
+        return String.format("2023%06d", Math.floorMod(suffix.hashCode(), 1_000_000));
     }
 
     private Post savePost(Member author, String title, BoardType boardType, LocalDateTime createdAt) {


### PR DESCRIPTION
## 개요
- main CI/CD를 막고 있던 hot-post 통합 테스트와 Flyway migration count 테스트를 현재 스키마/도메인 규칙에 맞춥니다.
- 이 PR이 통과하면 admin 기능 merge 이후 막혀 있던 배포 파이프라인을 다시 진행할 수 있습니다.

## 주요 변경
- `FlywayMigrationIntegrationTest`의 적용 migration 개수를 현재 버전 수(`V1~V9`)에 맞게 9로 수정
- `PostRepositoryIntegrationTest` fixture 회원 생성 로직을 현재 닉네임 최대 길이(15자) 규칙에 맞는 값으로 변경
- student number도 길이/유일성 충돌 없이 생성되도록 보정

## 검증
- `./gradlew test --tests 'kr.ac.knu.comit.post.domain.PostRepositoryIntegrationTest' --tests 'kr.ac.knu.comit.global.persistence.FlywayMigrationIntegrationTest'`
- `./gradlew test`
