### PR TITLE
fix(docs): serve API docs on stripped proxy path

### DIFF
--- a/src/main/java/kr/ac/knu/comit/global/config/WebMvcConfig.java
+++ b/src/main/java/kr/ac/knu/comit/global/config/WebMvcConfig.java
@@ -42,11 +42,17 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addRedirectViewController("/api/docs", "/api/docs/index.html");
+        registry.addRedirectViewController("/docs", "/docs/index.html");
     }
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/api/docs/**")
+                .addResourceLocations(
+                        "file:./docs/api/",
+                        "file:/app/api-docs/"
+                );
+        registry.addResourceHandler("/docs/**")
                 .addResourceLocations(
                         "file:./docs/api/",
                         "file:/app/api-docs/"

--- a/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
@@ -592,10 +592,28 @@ class AuthenticatedApiWebTest {
     }
 
     @Test
+    void redirectsStrippedDocsRootToIndexHtml() throws Exception {
+        // when & then
+        // 프록시가 /api prefix를 제거한 경로도 같은 문서 루트로 처리되어야 한다.
+        mockMvc.perform(get("/docs"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string("Location", "/docs/index.html"));
+    }
+
+    @Test
     void servesGeneratedApiDocsIndexScript() throws Exception {
         // when & then
         // 생성된 API 문서 정적 산출물이 앱 경로로 서빙되어야 한다.
         mockMvc.perform(get("/api/docs/index.js"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("window.API_DOCS")));
+    }
+
+    @Test
+    void servesGeneratedApiDocsIndexScriptOnStrippedDocsPath() throws Exception {
+        // when & then
+        // 프록시가 /api prefix를 제거한 경로에서도 정적 문서가 그대로 서빙되어야 한다.
+        mockMvc.perform(get("/docs/index.js"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("window.API_DOCS")));
     }


### PR DESCRIPTION
## 개요
- `/comit-staging/api/docs`가 nginx prefix 제거 후 내부 `/docs`로 들어오는 경로를 앱이 처리하지 못하던 문제를 수정합니다.

## 주요 변경
- `/docs` -> `/docs/index.html` 리다이렉트 추가
- `/docs/**` 정적 리소스 핸들러 추가
- 프록시 prefix 제거 경로에 대한 웹 테스트 추가

## 검증
- `./gradlew test --tests 'kr.ac.knu.comit.api.AuthenticatedApiWebTest'`

## Related
- live `comit-staging` API docs 500 hotfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation is now accessible at the `/docs` path with automatic redirection to the documentation index page and static resource serving.

* **Tests**
  * Added tests to validate documentation path routing and resource serving behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->