### PR TITLE
fix(auth): dev auth 쿠키 same-site를 분리한다

### DIFF
--- a/docs/guides/dev-auth.md
+++ b/docs/guides/dev-auth.md
@@ -39,6 +39,10 @@ curl -c cookies.txt -X POST \
 
 로그인 성공 시 `comit-dev-auth` 쿠키가 발급됩니다. (`200 OK`)
 
+- `local` 기본값은 `SameSite=Lax`
+- `staging` 기본값은 `SameSite=None; Secure`
+- 즉 `http://localhost:5173 -> https://chcse.knu.ac.kr/comit-staging/api` 같은 cross-site 프론트 테스트도 staging에서는 바로 가능합니다.
+
 ---
 
 ## 인증이 필요한 API 호출
@@ -90,6 +94,19 @@ await fetch("http://localhost:53080/posts", {
 });
 ```
 
+staging 프론트를 로컬에서 띄워 테스트할 때도 동일하게 `credentials: "include"`를 유지해야 합니다.
+
+```ts
+await fetch("https://chcse.knu.ac.kr/comit-staging/api/auth/dev/login?nickname=관리자&role=ADMIN", {
+  method: "POST",
+  credentials: "include",
+});
+
+await fetch("https://chcse.knu.ac.kr/comit-staging/api/admin/members?page=0&size=20", {
+  credentials: "include",
+});
+```
+
 ---
 
 ## 주의사항
@@ -97,3 +114,4 @@ await fetch("http://localhost:53080/posts", {
 - **production 환경에서는 이 엔드포인트가 존재하지 않습니다.** (`COMIT_DEV_AUTH_ENABLED` 미설정 시 Bean 미등록)
 - 테스트 계정 추가가 필요하면 `db/seed/V100__dev_seed.sql`에 INSERT IGNORE로 추가하세요.
 - `role` 파라미터를 생략하면 기본값은 `STUDENT`입니다.
+- dev auth 쿠키 정책은 `COMIT_DEV_AUTH_COOKIE_SAME_SITE`로 별도 제어합니다.

--- a/src/main/java/kr/ac/knu/comit/auth/config/ComitDevAuthProperties.java
+++ b/src/main/java/kr/ac/knu/comit/auth/config/ComitDevAuthProperties.java
@@ -1,0 +1,16 @@
+package kr.ac.knu.comit.auth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "comit.dev.auth")
+public class ComitDevAuthProperties {
+
+    private boolean enabled;
+    private String cookieSameSite;
+}

--- a/src/main/java/kr/ac/knu/comit/auth/controller/DevAuthController.java
+++ b/src/main/java/kr/ac/knu/comit/auth/controller/DevAuthController.java
@@ -1,6 +1,7 @@
 package kr.ac.knu.comit.auth.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
+import kr.ac.knu.comit.auth.config.ComitDevAuthProperties;
 import kr.ac.knu.comit.auth.config.ComitSsoProperties;
 import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.global.exception.BusinessException;
@@ -28,6 +29,7 @@ public class DevAuthController {
     public static final String DEV_AUTH_COOKIE = "comit-dev-auth";
 
     private final MemberRepository memberRepository;
+    private final ComitDevAuthProperties devAuthProperties;
     private final ComitSsoProperties ssoProperties;
 
     @PostMapping("/login")
@@ -54,7 +56,7 @@ public class DevAuthController {
         return ResponseCookie.from(DEV_AUTH_COOKIE, value)
                 .httpOnly(true)
                 .secure(ssoProperties.isCookieSecure())
-                .sameSite(ssoProperties.getCookieSameSite())
+                .sameSite(devAuthProperties.getCookieSameSite())
                 .path(cookiePath())
                 .maxAge(maxAge)
                 .build()

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -18,6 +18,7 @@ comit:
   dev:
     auth:
       enabled: ${COMIT_DEV_AUTH_ENABLED:true}
+      cookie-same-site: ${COMIT_DEV_AUTH_COOKIE_SAME_SITE:None}
   auth:
     bridge:
       enabled: ${COMIT_AUTH_BRIDGE_ENABLED:true}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,6 +62,10 @@ comit:
   web:
     cors:
       allowed-origins: ${COMIT_WEB_CORS_ALLOWED_ORIGINS:http://localhost:5173,https://knu-cse-comit-client.vercel.app,https://chcse.knu.ac.kr}
+  dev:
+    auth:
+      enabled: ${COMIT_DEV_AUTH_ENABLED:false}
+      cookie-same-site: ${COMIT_DEV_AUTH_COOKIE_SAME_SITE:Lax}
   auth:
     bridge:
       enabled: ${COMIT_AUTH_BRIDGE_ENABLED:false}

--- a/src/test/java/kr/ac/knu/comit/api/DevAuthWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/DevAuthWebTest.java
@@ -1,0 +1,66 @@
+package kr.ac.knu.comit.api;
+
+import static org.mockito.BDDMockito.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import kr.ac.knu.comit.auth.config.ComitDevAuthProperties;
+import kr.ac.knu.comit.auth.config.ComitSsoProperties;
+import kr.ac.knu.comit.auth.controller.DevAuthController;
+import kr.ac.knu.comit.global.exception.GlobalExceptionHandler;
+import kr.ac.knu.comit.member.domain.Member;
+import kr.ac.knu.comit.member.domain.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(DevAuthController.class)
+@Import({
+        GlobalExceptionHandler.class,
+        ComitSsoProperties.class,
+        ComitDevAuthProperties.class
+})
+@TestPropertySource(properties = {
+        "comit.dev.auth.enabled=true",
+        "comit.dev.auth.cookie-same-site=None",
+        "comit.auth.sso.cookie-secure=true",
+        "comit.auth.sso.cookie-path=/"
+})
+class DevAuthWebTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
+
+    @Test
+    void issuesCrossSiteCompatibleCookieForDevAuthLogin() throws Exception {
+        given(memberRepository.findByNicknameAndDeletedAtIsNull("관리자"))
+                .willReturn(Optional.of(Member.create(
+                        "dev-admin-001",
+                        "관리자",
+                        "010-1234-5678",
+                        "관리자",
+                        "2022000001",
+                        null,
+                        LocalDateTime.now()
+                )));
+
+        mockMvc.perform(post("/auth/dev/login")
+                        .param("nickname", "관리자")
+                        .param("role", "ADMIN"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Set-Cookie", containsString("SameSite=None")))
+                .andExpect(header().string("Set-Cookie", containsString("Secure")))
+                .andExpect(header().string("Set-Cookie", containsString("HttpOnly")));
+    }
+}


### PR DESCRIPTION
## 요약
- dev auth 쿠키의 SameSite 설정을 SSO 쿠키와 분리합니다.
- staging 기본값을 `SameSite=None`으로 두어 `localhost -> comit-staging` cross-site 개발 요청에서도 쿠키가 전송되도록 정리합니다.
- dev auth 가이드와 웹 테스트를 함께 갱신합니다.

## 검증
- `./gradlew compileTestJava`
- `./gradlew test --tests 'kr.ac.knu.comit.api.DevAuthWebTest'`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Development authentication now supports environment-specific cookie security configuration, enabling cross-site testing between local and cloud environments.

* **Documentation**
  * Added guide documenting development auth cookie policies and security defaults for different environments, including practical cross-site testing examples with code samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->