### PR TITLE
feat(post): BoardType에 INFO, NOTICE, EVENT 추가

### DIFF
--- a/src/main/java/kr/ac/knu/comit/post/domain/BoardType.java
+++ b/src/main/java/kr/ac/knu/comit/post/domain/BoardType.java
@@ -9,5 +9,20 @@ public enum BoardType {
     /**
      * 일반 자유 게시판.
      */
-    FREE
+    FREE,
+
+    /**
+     * 정보 공유 게시판.
+     */
+    INFO,
+
+    /**
+     * 공지사항 게시판.
+     */
+    NOTICE,
+
+    /**
+     * 이벤트 게시판.
+     */
+    EVENT
 }


### PR DESCRIPTION
## 요약
- `BoardType` enum에 `INFO`, `NOTICE`, `EVENT` 추가

## 참고
- `board_type` 컬럼이 `VARCHAR(20)` 이라 DB 마이그레이션 불필요
- 새 값은 기존 API(`GET /posts?boardType=INFO` 등)에서 바로 사용 가능