### PR TITLE
feat(image): S3 Presigned URL 발급 API 추가 (#36)

### DIFF
--- a/src/main/java/kr/ac/knu/comit/global/config/S3Config.java
+++ b/src/main/java/kr/ac/knu/comit/global/config/S3Config.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @EnableConfigurationProperties(S3Properties.class)
@@ -16,6 +17,16 @@ public class S3Config {
     @Bean
     public S3Client s3Client(S3Properties s3Properties) {
         return S3Client.builder()
+                .region(Region.of(s3Properties.region()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(s3Properties.accessKey(), s3Properties.secretKey())
+                ))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(S3Properties s3Properties) {
+        return S3Presigner.builder()
                 .region(Region.of(s3Properties.region()))
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(s3Properties.accessKey(), s3Properties.secretKey())

--- a/src/main/java/kr/ac/knu/comit/global/storage/S3StorageUploader.java
+++ b/src/main/java/kr/ac/knu/comit/global/storage/S3StorageUploader.java
@@ -8,15 +8,22 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 public class S3StorageUploader implements StorageUploader {
 
+    private static final Duration PRESIGNED_URL_EXPIRY = Duration.ofMinutes(10);
+
     private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
     private final S3Properties s3Properties;
 
     @Override
@@ -40,10 +47,31 @@ public class S3StorageUploader implements StorageUploader {
         return s3Properties.baseUrl() + "/" + key;
     }
 
+    public PresignedUploadUrls generatePresignedUploadUrl(String folder, String fileName, String contentType) {
+        String key = folder + "/" + UUID.randomUUID() + extractExtension(fileName);
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(
+                PutObjectPresignRequest.builder()
+                        .signatureDuration(PRESIGNED_URL_EXPIRY)
+                        .putObjectRequest(PutObjectRequest.builder()
+                                .bucket(s3Properties.bucketName())
+                                .key(key)
+                                .contentType(contentType)
+                                .build())
+                        .build()
+        );
+
+        String presignedUrl = presignedRequest.url().toString();
+        String imageUrl = s3Properties.baseUrl() + "/" + key;
+        return new PresignedUploadUrls(presignedUrl, imageUrl);
+    }
+
     private String extractExtension(String filename) {
         if (filename == null || !filename.contains(".")) {
             return "";
         }
         return filename.substring(filename.lastIndexOf("."));
     }
+
+    public record PresignedUploadUrls(String presignedUrl, String imageUrl) {}
 }

--- a/src/main/java/kr/ac/knu/comit/image/controller/ImageController.java
+++ b/src/main/java/kr/ac/knu/comit/image/controller/ImageController.java
@@ -3,6 +3,8 @@ package kr.ac.knu.comit.image.controller;
 import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.global.exception.ApiResponse;
 import kr.ac.knu.comit.image.controller.api.ImageControllerApi;
+import kr.ac.knu.comit.image.dto.PresignedUploadRequest;
+import kr.ac.knu.comit.image.dto.PresignedUploadResponse;
 import kr.ac.knu.comit.image.dto.UploadImageResponse;
 import kr.ac.knu.comit.image.service.ImageService;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +25,13 @@ public class ImageController implements ImageControllerApi {
             MemberPrincipal principal
     ) {
         return ResponseEntity.ok(ApiResponse.success(imageService.upload(file, folder)));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<PresignedUploadResponse>> generatePresignedUrl(
+            PresignedUploadRequest request,
+            MemberPrincipal principal
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(imageService.generatePresignedUrl(request)));
     }
 }

--- a/src/main/java/kr/ac/knu/comit/image/controller/api/ImageControllerApi.java
+++ b/src/main/java/kr/ac/knu/comit/image/controller/api/ImageControllerApi.java
@@ -1,5 +1,6 @@
 package kr.ac.knu.comit.image.controller.api;
 
+import jakarta.validation.Valid;
 import kr.ac.knu.comit.global.auth.AuthenticatedMember;
 import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.global.docs.annotation.ApiContract;
@@ -8,10 +9,13 @@ import kr.ac.knu.comit.global.docs.annotation.ApiError;
 import kr.ac.knu.comit.global.docs.annotation.Example;
 import kr.ac.knu.comit.global.docs.annotation.FieldDesc;
 import kr.ac.knu.comit.global.exception.ApiResponse;
+import kr.ac.knu.comit.image.dto.PresignedUploadRequest;
+import kr.ac.knu.comit.image.dto.PresignedUploadResponse;
 import kr.ac.knu.comit.image.dto.UploadImageResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -49,6 +53,37 @@ public interface ImageControllerApi {
     ResponseEntity<ApiResponse<UploadImageResponse>> uploadImage(
             @RequestPart MultipartFile file,
             @RequestParam String folder,
+            @AuthenticatedMember MemberPrincipal principal
+    );
+
+    @ApiDoc(
+            summary = "S3 Presigned URL 발급",
+            description = "클라이언트가 S3에 직접 업로드할 수 있는 presigned URL을 발급합니다. 발급된 presignedUrl로 PUT 요청을 보내 파일을 업로드하고, imageUrl을 게시글/프로필 등록에 사용하세요. URL 유효시간은 10분입니다.",
+            descriptions = {
+                    @FieldDesc(name = "fileName", value = "업로드할 파일명 (확장자 포함, 예: photo.jpg)"),
+                    @FieldDesc(name = "contentType", value = "파일 MIME 타입 (예: image/jpeg)"),
+                    @FieldDesc(name = "folder", value = "저장할 폴더명 (예: members, posts)"),
+                    @FieldDesc(name = "presignedUrl", value = "S3에 직접 PUT 업로드할 서명된 URL (유효시간 10분)"),
+                    @FieldDesc(name = "imageUrl", value = "업로드 완료 후 사용할 이미지 public URL")
+            },
+            errors = {
+                    @ApiError(code = "UNSUPPORTED_FILE_TYPE", when = "jpg, jpeg, png, webp, gif 외 contentType을 요청했을 때")
+            },
+            example = @Example(
+                    response = """
+                            {
+                              "result": "SUCCESS",
+                              "data": {
+                                "presignedUrl": "https://bucket.s3.ap-northeast-2.amazonaws.com/posts/550e8400.jpg?X-Amz-Signature=...",
+                                "imageUrl": "https://bucket.s3.ap-northeast-2.amazonaws.com/posts/550e8400.jpg"
+                              }
+                            }
+                            """
+            )
+    )
+    @PostMapping("/presigned")
+    ResponseEntity<ApiResponse<PresignedUploadResponse>> generatePresignedUrl(
+            @Valid @RequestBody PresignedUploadRequest request,
             @AuthenticatedMember MemberPrincipal principal
     );
 }

--- a/src/main/java/kr/ac/knu/comit/image/dto/PresignedUploadRequest.java
+++ b/src/main/java/kr/ac/knu/comit/image/dto/PresignedUploadRequest.java
@@ -1,0 +1,10 @@
+package kr.ac.knu.comit.image.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PresignedUploadRequest(
+        @NotBlank String fileName,
+        @NotBlank String contentType,
+        @NotBlank String folder
+) {
+}

--- a/src/main/java/kr/ac/knu/comit/image/dto/PresignedUploadResponse.java
+++ b/src/main/java/kr/ac/knu/comit/image/dto/PresignedUploadResponse.java
@@ -1,0 +1,7 @@
+package kr.ac.knu.comit.image.dto;
+
+public record PresignedUploadResponse(
+        String presignedUrl,
+        String imageUrl
+) {
+}

--- a/src/main/java/kr/ac/knu/comit/image/service/ImageService.java
+++ b/src/main/java/kr/ac/knu/comit/image/service/ImageService.java
@@ -2,7 +2,10 @@ package kr.ac.knu.comit.image.service;
 
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.StorageErrorCode;
+import kr.ac.knu.comit.global.storage.S3StorageUploader;
 import kr.ac.knu.comit.global.storage.StorageUploader;
+import kr.ac.knu.comit.image.dto.PresignedUploadRequest;
+import kr.ac.knu.comit.image.dto.PresignedUploadResponse;
 import kr.ac.knu.comit.image.dto.UploadImageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +23,7 @@ public class ImageService {
     );
 
     private final StorageUploader storageUploader;
+    private final S3StorageUploader s3StorageUploader;
 
     public UploadImageResponse upload(MultipartFile file, String folder) {
         if (file.getSize() > MAX_FILE_SIZE) {
@@ -30,5 +34,15 @@ public class ImageService {
         }
         String url = storageUploader.upload(file, folder);
         return new UploadImageResponse(url);
+    }
+
+    public PresignedUploadResponse generatePresignedUrl(PresignedUploadRequest request) {
+        if (!ALLOWED_CONTENT_TYPES.contains(request.contentType())) {
+            throw new BusinessException(StorageErrorCode.UNSUPPORTED_FILE_TYPE);
+        }
+        S3StorageUploader.PresignedUploadUrls urls = s3StorageUploader.generatePresignedUploadUrl(
+                request.folder(), request.fileName(), request.contentType()
+        );
+        return new PresignedUploadResponse(urls.presignedUrl(), urls.imageUrl());
     }
 }


### PR DESCRIPTION
## 요약

- `POST /images/presigned` 엔드포인트 추가
- 클라이언트가 S3에 직접 업로드할 수 있는 presigned URL 발급
- URL 유효시간 10분

## 변경 내용

| 파일 | 변경 |
|---|---|
| `S3Config.java` | `S3Presigner` 빈 추가 |
| `S3StorageUploader.java` | `generatePresignedUploadUrl()` 메서드 추가 |
| `PresignedUploadRequest.java` (신규) | `{ fileName, contentType, folder }` |
| `PresignedUploadResponse.java` (신규) | `{ presignedUrl, imageUrl }` |
| `ImageService.java` | `generatePresignedUrl()` 메서드 추가 |
| `ImageControllerApi.java` | `POST /images/presigned` 엔드포인트 정의 |
| `ImageController.java` | 엔드포인트 구현 |

## 업로드 플로우

```
1. 프론트 → POST /images/presigned   → { presignedUrl, imageUrl } 반환
2. 프론트 → PUT {presignedUrl}        → S3에 직접 업로드 (서버 미경유)
3. 프론트 → POST /posts (imageUrls)   → 게시글 생성
```

## 기존 API 영향

없음. 기존 `POST /images` (서버 중계 방식)는 그대로 유지됩니다.

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added presigned URL generation for image uploads. Users can now request a temporary presigned URL for uploading images directly to cloud storage, valid for 10 minutes. Includes content type validation to ensure only supported file types are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->