### PR TITLE
feat(member): GET /members/me 응답에 profileImageUrl 필드 추가

### DIFF
--- a/docs/api/member/MemberControllerApi.html
+++ b/docs/api/member/MemberControllerApi.html
@@ -295,6 +295,12 @@
     <td>현재 회원 닉네임</td>
 </tr>
 <tr>
+    <td><code>profileImageUrl</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>-</td>
+</tr>
+<tr>
     <td><code>studentNumber</code></td>
     <td><span class="type-chip type-string">String</span></td>
     <td><span class="badge-optional">optional</span></td>

--- a/src/main/java/kr/ac/knu/comit/member/dto/MemberProfileResponse.java
+++ b/src/main/java/kr/ac/knu/comit/member/dto/MemberProfileResponse.java
@@ -6,14 +6,16 @@ public record MemberProfileResponse(
         Long id,
         String nickname,
         String studentNumber,
-        boolean studentNumberVisible
+        boolean studentNumberVisible,
+        String profileImageUrl
 ) {
     public static MemberProfileResponse from(Member member) {
         return new MemberProfileResponse(
                 member.getId(),
                 member.getNickname(),
                 member.getStudentNumber(),
-                member.isStudentNumberVisible()
+                member.isStudentNumberVisible(),
+                member.getProfileImageUrl()
         );
     }
 }

--- a/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
@@ -134,7 +134,7 @@ class AuthenticatedApiWebTest {
         // given
         // 인증된 사용자의 프로필 응답을 준비한다.
         given(memberService.getMyProfile(1L))
-                .willReturn(new MemberProfileResponse(1L, "comit-user", "2020111111", true));
+                .willReturn(new MemberProfileResponse(1L, "comit-user", "2020111111", true, null));
 
         // when & then
         // 인증 헤더가 컨트롤러까지 주입되고 응답이 정상 직렬화되는지 확인한다.

--- a/src/test/java/kr/ac/knu/comit/api/SsoAuthWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/SsoAuthWebTest.java
@@ -101,7 +101,7 @@ class SsoAuthWebTest {
         given(memberService.hasDeletedMember("sso-sub-1")).willReturn(false);
         given(memberService.hasActiveMember("sso-sub-1")).willReturn(true);
         given(memberService.getMyProfile(1L))
-                .willReturn(new MemberProfileResponse(1L, "comit-user", "2023012780", true));
+                .willReturn(new MemberProfileResponse(1L, "comit-user", "2023012780", true, null));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `MemberProfileResponse`에 `profileImageUrl` 필드 추가
- `Member.getProfileImageUrl()`로 매핑, 미설정 시 `null` 응답
- 영향받는 테스트 2건 생성자 인자 수정

## Test plan
- [ ] `GET /members/me` 응답에 `profileImageUrl` 포함 확인
- [ ] 프로필 이미지 없는 경우 `null` 반환 확인
- [ ] 기존 웹 계층 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Member profiles now include a profile image URL in API responses.

* **Documentation**
  * API reference updated to document the new optional profileImageUrl field.

* **Tests**
  * Server tests updated to account for the added profileImageUrl field in mocked responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->