### PR TITLE
feat: 회원가입 프로필 이미지 presigned 및 이벤트 관리자 수정 API 추가

### DIFF
--- a/docs/api/auth/RegisterControllerApi.html
+++ b/docs/api/auth/RegisterControllerApi.html
@@ -252,7 +252,11 @@
             <a class="back-link" href="../index.html">← API Index</a>
             <h1>RegisterControllerApi</h1>
             <p>인터페이스 기반으로 추출한 엔드포인트 문서입니다.</p>
-            <nav><a href="#getPrefill">
+            <nav><a href="#createProfileImagePresignedUpload">
+    <strong>회원가입 프로필 이미지 업로드용 presigned URL 발급</strong>
+    <span>POST /auth/register/profile-image/presigned</span>
+</a>
+<a href="#getPrefill">
     <strong>회원가입 prefill 조회</strong>
     <span>GET /auth/register/prefill</span>
 </a>
@@ -262,7 +266,221 @@
 </a>
 </nav>
         </aside>
-        <section class="content"><article class="endpoint" id="getPrefill">
+        <section class="content"><article class="endpoint" id="createProfileImagePresignedUpload">
+    <div class="eyebrow">POST</div>
+    <h2>회원가입 프로필 이미지 업로드용 presigned URL 발급</h2>
+    <p>회원가입 전 단계에서 SSO 토큰 쿠키를 검증한 뒤 프로필 이미지 업로드용 presigned URL을 발급합니다.</p>
+    <div class="path-box"><span class="method">POST</span>/auth/register/profile-image/presigned</div>
+    <div class="section-grid"><section class="card">
+    <h3>요청 바디 필드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>필드명</th>
+            <th>타입</th>
+            <th>필수 여부</th>
+            <th>설명</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>contentType</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>업로드할 파일의 MIME 타입입니다.</td>
+</tr>
+<tr>
+    <td><code>fileName</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>업로드할 파일 이름입니다.</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>응답 바디 필드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>필드명</th>
+            <th>타입</th>
+            <th>필수 여부</th>
+            <th>설명</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>imageUrl</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>회원가입 요청의 profileImageUrl에 전달할 최종 이미지 URL입니다.</td>
+</tr>
+<tr>
+    <td><code>presignedUrl</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>S3 업로드에 사용할 presigned URL입니다.</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>에러 응답 필드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>필드명</th>
+            <th>타입</th>
+            <th>필수 여부</th>
+            <th>설명</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>type</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>문제 유형을 식별하는 URI path입니다.</td>
+</tr>
+<tr>
+    <td><code>title</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>HTTP 상태를 요약한 제목입니다.</td>
+</tr>
+<tr>
+    <td><code>status</code></td>
+    <td><span class="type-chip type-number">Integer</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>HTTP 상태 코드입니다.</td>
+</tr>
+<tr>
+    <td><code>detail</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>클라이언트에 노출할 에러 설명입니다.</td>
+</tr>
+<tr>
+    <td><code>instance</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>에러가 발생한 요청 경로입니다.</td>
+</tr>
+<tr>
+    <td><code>errorCode</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>프론트엔드 분기에 사용하는 안정적인 에러 코드입니다.</td>
+</tr>
+<tr>
+    <td><code>invalidFields</code></td>
+    <td><span class="type-chip type-collection">List&lt;ProblemFieldViolation&gt;</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>validation 에러에서만 포함됩니다. 필드명과 검증 메시지 목록입니다.</td>
+</tr>
+<tr>
+    <td><code>errorTrackingId</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>서버 내부 오류에서만 포함됩니다. 로그 추적용 식별자입니다.</td>
+</tr>
+<tr>
+    <td><code>timestamp</code></td>
+    <td><span class="type-chip type-datetime">OffsetDateTime</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>에러 응답 생성 시각입니다.</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>에러 코드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>errorCode</th>
+            <th>HTTP 상태</th>
+            <th>type</th>
+            <th>detail</th>
+            <th>발생 조건</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>INVALID_REQUEST</code></td>
+    <td>400</td>
+    <td><code>/problems/common/invalid-request</code></td>
+    <td>입력값이 올바르지 않습니다.</td>
+    <td>요청 본문이 검증 규칙을 만족하지 않을 때</td>
+</tr>
+<tr>
+    <td><code>UNAUTHORIZED</code></td>
+    <td>401</td>
+    <td><code>/problems/common/unauthorized</code></td>
+    <td>인증이 필요합니다.</td>
+    <td>SSO 토큰 쿠키가 없거나 유효하지 않을 때</td>
+</tr>
+<tr>
+    <td><code>FORBIDDEN</code></td>
+    <td>403</td>
+    <td><code>/problems/common/forbidden</code></td>
+    <td>접근 권한이 없습니다.</td>
+    <td>외부 사용자(EXTERNAL)가 호출할 때</td>
+</tr>
+<tr>
+    <td><code>MEMBER_ALREADY_EXISTS</code></td>
+    <td>409</td>
+    <td><code>/problems/member/already-exists</code></td>
+    <td>이미 가입된 회원입니다.</td>
+    <td>이미 가입된 회원이 호출할 때</td>
+</tr>
+<tr>
+    <td><code>UNSUPPORTED_FILE_TYPE</code></td>
+    <td>400</td>
+    <td><code>/problems/storage/unsupported-file-type</code></td>
+    <td>지원하지 않는 파일 형식입니다. (허용: jpg, jpeg, png, webp, gif)</td>
+    <td>지원하지 않는 파일 형식으로 요청할 때</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>요청 예시</h3>
+    <pre><code>{
+  &quot;fileName&quot; : &quot;profile.png&quot;,
+  &quot;contentType&quot; : &quot;image/png&quot;
+}</code></pre>
+</section>
+<section class="card">
+    <h3>응답 예시</h3>
+    <pre><code>{
+  &quot;result&quot; : &quot;SUCCESS&quot;,
+  &quot;data&quot; : {
+    &quot;presignedUrl&quot; : &quot;https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png?signature=...&quot;,
+    &quot;imageUrl&quot; : &quot;https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png&quot;
+  }
+}</code></pre>
+</section>
+<section class="card">
+    <h3>에러 예시</h3>
+    <pre><code>{
+  &quot;type&quot; : &quot;/problems/common/invalid-request&quot;,
+  &quot;title&quot; : &quot;Bad Request&quot;,
+  &quot;status&quot; : 400,
+  &quot;detail&quot; : &quot;입력값이 올바르지 않습니다.&quot;,
+  &quot;instance&quot; : &quot;/auth/register/profile-image/presigned&quot;,
+  &quot;errorCode&quot; : &quot;INVALID_REQUEST&quot;,
+  &quot;invalidFields&quot; : [ {
+    &quot;field&quot; : &quot;fieldName&quot;,
+    &quot;message&quot; : &quot;유효하지 않은 입력값입니다.&quot;
+  } ],
+  &quot;timestamp&quot; : &quot;2026-03-24T03:10:00Z&quot;
+}</code></pre>
+</section>
+</div>
+</article>
+<article class="endpoint" id="getPrefill">
     <div class="eyebrow">GET</div>
     <h2>회원가입 prefill 조회</h2>
     <p>SSO 토큰 쿠키를 검증하고 회원가입 폼에 미리 채울 값을 반환합니다.</p>

--- a/docs/api/index.js
+++ b/docs/api/index.js
@@ -1,9 +1,9 @@
 window.API_DOCS = [
 {
   title: "RegisterControllerApi",
-  summary: "SSO 토큰 쿠키를 검증하고 회원가입 폼에 미리 채울 값을 반환합니다.",
+  summary: "회원가입 전 단계에서 SSO 토큰 쿠키를 검증한 뒤 프로필 이미지 업로드용 presigned URL을 발급합니다.",
   href: "./auth/RegisterControllerApi.html",
-  endpointCount: 2,
+  endpointCount: 3,
   sectionPath: "auth"
 },
 {
@@ -66,7 +66,7 @@ window.API_DOCS = [
   title: "AdminPostControllerApi",
   summary: "관리자가 NOTICE, EVENT, INFO 게시판에 게시글을 작성합니다. QNA, FREE 게시판에는 작성할 수 없습니다.",
   href: "./post/AdminPostControllerApi.html",
-  endpointCount: 4,
+  endpointCount: 6,
   sectionPath: "post"
 },
 {

--- a/docs/api/post/AdminPostControllerApi.html
+++ b/docs/api/post/AdminPostControllerApi.html
@@ -260,9 +260,17 @@
     <strong>게시글 삭제 (관리자)</strong>
     <span>DELETE /admin/posts/{postId}</span>
 </a>
+<a href="#getPost">
+    <strong>게시글 상세 조회 (관리자)</strong>
+    <span>GET /admin/posts/{postId}</span>
+</a>
 <a href="#getPosts">
     <strong>게시글 목록 조회 (관리자)</strong>
     <span>GET /admin/posts</span>
+</a>
+<a href="#updatePost">
+    <strong>공지/이벤트/정보 게시글 수정 (관리자)</strong>
+    <span>PATCH /admin/posts/{postId}</span>
 </a>
 <a href="#updateVisibility">
     <strong>게시글 숨김/복원 (관리자)</strong>
@@ -639,6 +647,259 @@
 </section>
 </div>
 </article>
+<article class="endpoint" id="getPost">
+    <div class="eyebrow">GET</div>
+    <h2>게시글 상세 조회 (관리자)</h2>
+    <p>관리자가 공지/이벤트/정보 게시글 상세 내용을 조회합니다. 수정 화면 진입에 필요한 본문, 태그, 이미지 URL을 포함합니다.</p>
+    <div class="path-box"><span class="method">GET</span>/admin/posts/{postId}</div>
+    <div class="section-grid"><section class="card">
+    <h3>경로 변수</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>필드명</th>
+            <th>타입</th>
+            <th>필수 여부</th>
+            <th>설명</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>postId</code></td>
+    <td><span class="type-chip type-number">Long</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>조회할 게시글 ID입니다.</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>응답 바디 필드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>필드명</th>
+            <th>타입</th>
+            <th>필수 여부</th>
+            <th>설명</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>authorNickname</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>-</td>
+</tr>
+<tr>
+    <td><code>boardType</code></td>
+    <td><span class="type-chip type-custom">BoardType</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>게시판 유형입니다.</td>
+</tr>
+<tr>
+    <td><code>content</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>게시글 본문입니다.</td>
+</tr>
+<tr>
+    <td><code>createdAt</code></td>
+    <td><span class="type-chip type-datetime">LocalDateTime</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>-</td>
+</tr>
+<tr>
+    <td><code>hiddenByAdmin</code></td>
+    <td><span class="type-chip type-boolean">boolean</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>관리자 숨김 여부입니다.</td>
+</tr>
+<tr>
+    <td><code>id</code></td>
+    <td><span class="type-chip type-number">Long</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>-</td>
+</tr>
+<tr>
+    <td><code>imageUrls</code></td>
+    <td><span class="type-chip type-collection">List&lt;String&gt;</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>첨부 이미지 URL 목록입니다.</td>
+</tr>
+<tr>
+    <td><code>likeCount</code></td>
+    <td><span class="type-chip type-number">int</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>-</td>
+</tr>
+<tr>
+    <td><code>tags</code></td>
+    <td><span class="type-chip type-collection">List&lt;String&gt;</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>태그 목록입니다.</td>
+</tr>
+<tr>
+    <td><code>title</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>게시글 제목입니다.</td>
+</tr>
+<tr>
+    <td><code>updatedAt</code></td>
+    <td><span class="type-chip type-datetime">LocalDateTime</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>-</td>
+</tr>
+<tr>
+    <td><code>viewCount</code></td>
+    <td><span class="type-chip type-number">int</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>-</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>에러 응답 필드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>필드명</th>
+            <th>타입</th>
+            <th>필수 여부</th>
+            <th>설명</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>type</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>문제 유형을 식별하는 URI path입니다.</td>
+</tr>
+<tr>
+    <td><code>title</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>HTTP 상태를 요약한 제목입니다.</td>
+</tr>
+<tr>
+    <td><code>status</code></td>
+    <td><span class="type-chip type-number">Integer</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>HTTP 상태 코드입니다.</td>
+</tr>
+<tr>
+    <td><code>detail</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>클라이언트에 노출할 에러 설명입니다.</td>
+</tr>
+<tr>
+    <td><code>instance</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>에러가 발생한 요청 경로입니다.</td>
+</tr>
+<tr>
+    <td><code>errorCode</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>프론트엔드 분기에 사용하는 안정적인 에러 코드입니다.</td>
+</tr>
+<tr>
+    <td><code>invalidFields</code></td>
+    <td><span class="type-chip type-collection">List&lt;ProblemFieldViolation&gt;</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>validation 에러에서만 포함됩니다. 필드명과 검증 메시지 목록입니다.</td>
+</tr>
+<tr>
+    <td><code>errorTrackingId</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>서버 내부 오류에서만 포함됩니다. 로그 추적용 식별자입니다.</td>
+</tr>
+<tr>
+    <td><code>timestamp</code></td>
+    <td><span class="type-chip type-datetime">OffsetDateTime</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>에러 응답 생성 시각입니다.</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>에러 코드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>errorCode</th>
+            <th>HTTP 상태</th>
+            <th>type</th>
+            <th>detail</th>
+            <th>발생 조건</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>UNAUTHORIZED</code></td>
+    <td>401</td>
+    <td><code>/problems/common/unauthorized</code></td>
+    <td>인증이 필요합니다.</td>
+    <td>인증 정보가 없거나 유효한 회원을 식별할 수 없을 때</td>
+</tr>
+<tr>
+    <td><code>FORBIDDEN</code></td>
+    <td>403</td>
+    <td><code>/problems/common/forbidden</code></td>
+    <td>접근 권한이 없습니다.</td>
+    <td>관리자 권한이 없는 사용자가 요청할 때</td>
+</tr>
+<tr>
+    <td><code>POST_NOT_FOUND</code></td>
+    <td>404</td>
+    <td><code>/problems/post/not-found</code></td>
+    <td>존재하지 않는 게시글입니다.</td>
+    <td>존재하지 않는 게시글 ID로 요청할 때</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>응답 예시</h3>
+    <pre><code>{
+  &quot;result&quot; : &quot;SUCCESS&quot;,
+  &quot;data&quot; : {
+    &quot;id&quot; : 42,
+    &quot;boardType&quot; : &quot;EVENT&quot;,
+    &quot;title&quot; : &quot;세미나 신청 안내&quot;,
+    &quot;content&quot; : &quot;상세 일정 안내입니다.&quot;,
+    &quot;authorNickname&quot; : &quot;관리자&quot;,
+    &quot;likeCount&quot; : 0,
+    &quot;viewCount&quot; : 10,
+    &quot;hiddenByAdmin&quot; : false,
+    &quot;tags&quot; : [ &quot;세미나&quot;, &quot;행사&quot; ],
+    &quot;imageUrls&quot; : [ ],
+    &quot;createdAt&quot; : &quot;2026-04-14T10:00:00&quot;,
+    &quot;updatedAt&quot; : &quot;2026-04-14T10:05:00&quot;
+  }
+}</code></pre>
+</section>
+<section class="card">
+    <h3>에러 예시</h3>
+    <pre><code>{
+  &quot;type&quot; : &quot;/problems/common/unauthorized&quot;,
+  &quot;title&quot; : &quot;Unauthorized&quot;,
+  &quot;status&quot; : 401,
+  &quot;detail&quot; : &quot;인증이 필요합니다.&quot;,
+  &quot;instance&quot; : &quot;/admin/posts/{postId}&quot;,
+  &quot;errorCode&quot; : &quot;UNAUTHORIZED&quot;,
+  &quot;timestamp&quot; : &quot;2026-03-24T03:10:00Z&quot;
+}</code></pre>
+</section>
+</div>
+</article>
 <article class="endpoint" id="getPosts">
     <div class="eyebrow">GET</div>
     <h2>게시글 목록 조회 (관리자)</h2>
@@ -839,6 +1100,227 @@
   &quot;status&quot; : 401,
   &quot;detail&quot; : &quot;인증이 필요합니다.&quot;,
   &quot;instance&quot; : &quot;/admin/posts&quot;,
+  &quot;errorCode&quot; : &quot;UNAUTHORIZED&quot;,
+  &quot;timestamp&quot; : &quot;2026-03-24T03:10:00Z&quot;
+}</code></pre>
+</section>
+</div>
+</article>
+<article class="endpoint" id="updatePost">
+    <div class="eyebrow">PATCH</div>
+    <h2>공지/이벤트/정보 게시글 수정 (관리자)</h2>
+    <p>관리자가 NOTICE, EVENT, INFO 게시판의 게시글을 수정합니다. 수정 시 게시판 유형, 제목, 본문, 태그, 이미지 URL을 통째로 교체합니다.</p>
+    <div class="path-box"><span class="method">PATCH</span>/admin/posts/{postId}</div>
+    <div class="section-grid"><section class="card">
+    <h3>경로 변수</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>필드명</th>
+            <th>타입</th>
+            <th>필수 여부</th>
+            <th>설명</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>postId</code></td>
+    <td><span class="type-chip type-number">Long</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>수정할 게시글 ID입니다.</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>요청 바디 필드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>필드명</th>
+            <th>타입</th>
+            <th>필수 여부</th>
+            <th>설명</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>boardType</code></td>
+    <td><span class="type-chip type-custom">BoardType</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>게시판 유형입니다. NOTICE, EVENT, INFO 중 하나만 허용됩니다.</td>
+</tr>
+<tr>
+    <td><code>content</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>수정할 게시글 내용입니다.</td>
+</tr>
+<tr>
+    <td><code>imageUrls</code></td>
+    <td><span class="type-chip type-collection">List&lt;String&gt;</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>첨부 이미지 URL 목록입니다. 생략 가능합니다.</td>
+</tr>
+<tr>
+    <td><code>tags</code></td>
+    <td><span class="type-chip type-collection">List&lt;String&gt;</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>태그 목록입니다. 생략 가능합니다.</td>
+</tr>
+<tr>
+    <td><code>title</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>수정할 게시글 제목입니다.</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>에러 응답 필드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>필드명</th>
+            <th>타입</th>
+            <th>필수 여부</th>
+            <th>설명</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>type</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>문제 유형을 식별하는 URI path입니다.</td>
+</tr>
+<tr>
+    <td><code>title</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>HTTP 상태를 요약한 제목입니다.</td>
+</tr>
+<tr>
+    <td><code>status</code></td>
+    <td><span class="type-chip type-number">Integer</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>HTTP 상태 코드입니다.</td>
+</tr>
+<tr>
+    <td><code>detail</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>클라이언트에 노출할 에러 설명입니다.</td>
+</tr>
+<tr>
+    <td><code>instance</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>에러가 발생한 요청 경로입니다.</td>
+</tr>
+<tr>
+    <td><code>errorCode</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>프론트엔드 분기에 사용하는 안정적인 에러 코드입니다.</td>
+</tr>
+<tr>
+    <td><code>invalidFields</code></td>
+    <td><span class="type-chip type-collection">List&lt;ProblemFieldViolation&gt;</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>validation 에러에서만 포함됩니다. 필드명과 검증 메시지 목록입니다.</td>
+</tr>
+<tr>
+    <td><code>errorTrackingId</code></td>
+    <td><span class="type-chip type-string">String</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>서버 내부 오류에서만 포함됩니다. 로그 추적용 식별자입니다.</td>
+</tr>
+<tr>
+    <td><code>timestamp</code></td>
+    <td><span class="type-chip type-datetime">OffsetDateTime</span></td>
+    <td><span class="badge-required">required</span></td>
+    <td>에러 응답 생성 시각입니다.</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>에러 코드</h3>
+    <table>
+    <thead>
+        <tr>
+            <th>errorCode</th>
+            <th>HTTP 상태</th>
+            <th>type</th>
+            <th>detail</th>
+            <th>발생 조건</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+    <td><code>UNAUTHORIZED</code></td>
+    <td>401</td>
+    <td><code>/problems/common/unauthorized</code></td>
+    <td>인증이 필요합니다.</td>
+    <td>인증 정보가 없거나 유효한 회원을 식별할 수 없을 때</td>
+</tr>
+<tr>
+    <td><code>INVALID_REQUEST</code></td>
+    <td>400</td>
+    <td><code>/problems/common/invalid-request</code></td>
+    <td>입력값이 올바르지 않습니다.</td>
+    <td>요청 본문이 검증 규칙을 만족하지 않을 때</td>
+</tr>
+<tr>
+    <td><code>FORBIDDEN</code></td>
+    <td>403</td>
+    <td><code>/problems/common/forbidden</code></td>
+    <td>접근 권한이 없습니다.</td>
+    <td>관리자 권한이 없는 사용자가 요청할 때</td>
+</tr>
+<tr>
+    <td><code>FORBIDDEN_BOARD_TYPE</code></td>
+    <td>400</td>
+    <td><code>/problems/post/forbidden-board-type</code></td>
+    <td>해당 게시판 유형은 관리자만 작성할 수 있습니다.</td>
+    <td>NOTICE, EVENT, INFO 외 boardType으로 요청할 때</td>
+</tr>
+<tr>
+    <td><code>POST_NOT_FOUND</code></td>
+    <td>404</td>
+    <td><code>/problems/post/not-found</code></td>
+    <td>존재하지 않는 게시글입니다.</td>
+    <td>존재하지 않는 게시글 ID로 요청할 때</td>
+</tr>
+</tbody>
+</table>
+
+</section>
+<section class="card">
+    <h3>요청 예시</h3>
+    <pre><code>{
+  &quot;boardType&quot; : &quot;EVENT&quot;,
+  &quot;title&quot; : &quot;세미나 신청 안내 수정&quot;,
+  &quot;content&quot; : &quot;수정된 상세 일정 안내입니다.&quot;,
+  &quot;tags&quot; : [ &quot;세미나&quot;, &quot;행사&quot; ],
+  &quot;imageUrls&quot; : [ ]
+}</code></pre>
+</section>
+<section class="card">
+    <h3>응답 예시</h3>
+    <pre><code>{
+  &quot;result&quot; : &quot;SUCCESS&quot;
+}</code></pre>
+</section>
+<section class="card">
+    <h3>에러 예시</h3>
+    <pre><code>{
+  &quot;type&quot; : &quot;/problems/common/unauthorized&quot;,
+  &quot;title&quot; : &quot;Unauthorized&quot;,
+  &quot;status&quot; : 401,
+  &quot;detail&quot; : &quot;인증이 필요합니다.&quot;,
+  &quot;instance&quot; : &quot;/admin/posts/{postId}&quot;,
   &quot;errorCode&quot; : &quot;UNAUTHORIZED&quot;,
   &quot;timestamp&quot; : &quot;2026-03-24T03:10:00Z&quot;
 }</code></pre>

--- a/docs/api/spec/sso-registration-flow.html
+++ b/docs/api/spec/sso-registration-flow.html
@@ -80,6 +80,7 @@
 <ul>
 <li><code>SsoCallbackPendingRegistration</code> 결과 타입 추가</li>
 <li><code>GET /auth/register/prefill</code> — JWT에서 pre-fill 가능한 값 반환</li>
+<li><code>POST /auth/register/profile-image/presigned</code> — 회원가입 전 프로필 이미지 업로드용 presigned URL 발급</li>
 <li><code>POST /auth/register</code> — 회원가입 완료 API</li>
 <li><code>Member</code> 도메인 필드 확장 (<code>name</code>, <code>phone</code>, <code>majorTrack</code>, <code>agreedAt</code>)</li>
 <li><code>ExternalIdentity</code> <code>major</code> 필드 추가</li>
@@ -88,7 +89,6 @@
 </ul>
 <h3>1.3 Out of Scope</h3>
 <ul>
-<li>프로필 이미지</li>
 <li>약관 버전 관리</li>
 <li>회원가입 후 이메일 인증</li>
 </ul>
@@ -97,6 +97,7 @@
 <li>미가입 INTERNAL 사용자가 SSO 콜백 후 register URL로 리디렉션된다.</li>
 <li><code>GET /auth/register/prefill</code>에서 name, studentNumber, major가 반환된다.</li>
 <li><code>POST /auth/register</code>로 회원가입 완료 후 정상 서비스 진입이 된다.</li>
+<li>회원가입 전 단계에서 프로필 이미지를 업로드해 <code>profileImageUrl</code>을 register 요청에 포함할 수 있다.</li>
 <li>미가입 상태에서 <code>/auth/register/**</code> 외 API 접근 시 <code>REGISTRATION_REQUIRED</code> 에러가 반환된다.</li>
 <li>기존 가입 사용자의 로그인 플로우는 그대로 동작한다.</li>
 </ul>
@@ -185,6 +186,36 @@
 <li><code>200 OK</code>가 반환된다.</li>
 <li>이후 일반 API 접근이 가능해진다.</li>
 </ul>
+<h3>Scenario C-1. 미가입 사용자가 회원가입 전 프로필 이미지 업로드용 presigned URL을 발급받는다</h3>
+<p>Given:</p>
+<ul>
+<li>SSO 토큰 쿠키가 세팅되어 있다.</li>
+<li>DB에 해당 ssoSub의 멤버가 없다.</li>
+<li>업로드 파일 형식은 이미지다.</li>
+</ul>
+<p>When:</p>
+<ul>
+<li><code>POST /auth/register/profile-image/presigned</code>를 호출한다.</li>
+</ul>
+<p>Then:</p>
+<ul>
+<li>서버는 <code>members</code> 경로에 업로드할 presigned URL과 최종 <code>imageUrl</code>을 반환한다.</li>
+<li>프론트는 이 <code>imageUrl</code>을 최종 <code>POST /auth/register</code>의 <code>profileImageUrl</code>로 전달할 수 있다.</li>
+</ul>
+<h3>Scenario C-2. 이미 가입된 사용자는 회원가입 전용 프로필 이미지 presigned URL을 발급받을 수 없다</h3>
+<p>Given:</p>
+<ul>
+<li>SSO 토큰 쿠키가 세팅되어 있다.</li>
+<li>DB에 해당 ssoSub의 멤버가 이미 존재한다.</li>
+</ul>
+<p>When:</p>
+<ul>
+<li><code>POST /auth/register/profile-image/presigned</code>를 호출한다.</li>
+</ul>
+<p>Then:</p>
+<ul>
+<li><code>409 MEMBER_ALREADY_EXISTS</code> 에러가 반환된다.</li>
+</ul>
 <h3>Scenario D. 미가입 상태에서 일반 API에 접근한다</h3>
 <p>Given:</p>
 <ul>
@@ -232,6 +263,8 @@
 <li>FR-1: SSO 콜백 시 INTERNAL + 미가입이면 <code>SsoCallbackPendingRegistration</code>을 반환하고 register URL로 리디렉션한다.</li>
 <li>FR-2: <code>GET /auth/register/prefill</code>은 SSO 쿠키를 검증하고 JWT에서 <code>name</code>, <code>studentNumber</code>, <code>major</code>를 반환한다.</li>
 <li>FR-3: <code>POST /auth/register</code>는 <code>nickname</code>, <code>phone</code>, <code>agreedToTerms</code>를 받는다.</li>
+<li>FR-3-1: <code>POST /auth/register/profile-image/presigned</code>는 <code>fileName</code>, <code>contentType</code>을 받고 presigned URL과 <code>imageUrl</code>을 반환한다.</li>
+<li>FR-3-2: 회원가입 전용 프로필 이미지 presigned 발급은 <code>members</code> 폴더만 사용하며 클라이언트가 임의 폴더를 지정할 수 없다.</li>
 <li>FR-4: <code>agreedToTerms</code>가 <code>false</code>이면 <code>400 INVALID_REQUEST</code>를 반환한다.</li>
 <li>FR-5: <code>nickname</code>은 1~15자, 중복 불가.</li>
 <li>FR-6: <code>phone</code>은 필수 입력값이다.</li>
@@ -244,6 +277,7 @@
 <h3>5.1 Preconditions</h3>
 <ul>
 <li><code>GET /auth/register/prefill</code>, <code>POST /auth/register</code> 모두 유효한 SSO 토큰 쿠키 필요</li>
+<li><code>POST /auth/register/profile-image/presigned</code>도 유효한 SSO 토큰 쿠키 필요</li>
 <li><code>agreedToTerms == true</code></li>
 </ul>
 <h3>5.2 Postconditions</h3>
@@ -251,16 +285,19 @@
 <li>Member 생성: <code>name</code>, <code>phone</code>, <code>nickname</code>, <code>studentNumber</code>, <code>majorTrack</code>, <code>agreedAt</code>, <code>ssoSub</code> 저장</li>
 <li><code>agreedAt = 서버 현재 시각</code></li>
 <li>이후 <code>SsoAuthenticationFilter</code>에서 정상 멤버로 인식</li>
+<li>회원가입 전용 프로필 이미지 업로드는 member row를 생성하지 않는다.</li>
 </ul>
 <h3>5.3 Invariants</h3>
 <ul>
 <li><code>name</code>, <code>studentNumber</code>, <code>major</code>는 서버가 JWT에서 직접 읽는다. 프론트 전달값을 신뢰하지 않는다.</li>
+<li><code>profileImageUrl</code>은 회원가입 전용 presigned 발급 API가 반환한 URL만 사용한다.</li>
 <li>한 ssoSub에 하나의 멤버만 존재한다.</li>
 <li><code>agreedToTerms == false</code>이면 회원가입이 완료되지 않는다.</li>
 </ul>
 <h3>5.4 Forbidden Rules</h3>
 <ul>
 <li>프론트에서 <code>name</code>, <code>studentNumber</code>, <code>major</code>를 전달받아 저장하는 것</li>
+<li>기존 <code>POST /images/presigned</code>를 회원가입 전 단계에서 직접 호출하는 것</li>
 <li>미가입 상태에서 일반 API 접근 허용</li>
 <li>auto-create로 닉네임을 자동 생성하는 것</li>
 <li>soft delete 된 기존 회원을 새 회원가입 플로우로 다시 진입시키는 것</li>
@@ -315,6 +352,30 @@
 <p>- <code>401 UNAUTHORIZED</code>: 쿠키 없음</p>
 <p>- <code>409 MEMBER_ALREADY_EXISTS</code>: 이미 가입된 ssoSub</p>
 <p>- <code>409 DUPLICATE_NICKNAME</code>: 닉네임 중복</p>
+<p><strong>POST /auth/register/profile-image/presigned</strong></p>
+<ul>
+<li>Auth: SSO 토큰 쿠키 필요</li>
+<li>Request:</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;fileName&quot;: &quot;profile.png&quot;,
+  &quot;contentType&quot;: &quot;image/png&quot;
+}</code></pre>
+<ul>
+<li>Response:</li>
+</ul>
+<pre><code class="language-json">{
+  &quot;presignedUrl&quot;: &quot;https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png?signature=...&quot;,
+  &quot;imageUrl&quot;: &quot;https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png&quot;
+}</code></pre>
+<ul>
+<li>Errors:</li>
+</ul>
+<p>- <code>400 INVALID_REQUEST</code>: fileName 또는 contentType 누락</p>
+<p>- <code>400 UNSUPPORTED_FILE_TYPE</code>: 허용되지 않은 이미지 형식</p>
+<p>- <code>401 UNAUTHORIZED</code>: 쿠키 없음 또는 만료</p>
+<p>- <code>403 FORBIDDEN</code>: EXTERNAL 사용자</p>
+<p>- <code>409 MEMBER_ALREADY_EXISTS</code>: 이미 가입된 ssoSub</p>
 <h3>7.2 Persistence Contract</h3>
 <ul>
 <li>Member 테이블 신규 컬럼:</li>
@@ -329,6 +390,7 @@
 <ul>
 <li><code>name</code>, <code>studentNumber</code>, <code>major</code>는 JWT에서만 읽는다.</li>
 <li>register API는 SSO 쿠키 검증 없이 접근 불가.</li>
+<li>회원가입 전 프로필 이미지 업로드도 SSO 쿠키 검증 없이 접근 불가.</li>
 </ul>
 <h3>8.2 Technical Constraints</h3>
 <ul>
@@ -341,6 +403,7 @@
 <ul>
 <li>미가입 INTERNAL 콜백 → register URL 리디렉션</li>
 <li>prefill 조회 성공</li>
+<li>회원가입 전용 프로필 이미지 presigned URL 발급 성공</li>
 <li>회원가입 완료 → 멤버 생성 확인</li>
 <li>기가입 사용자 콜백 → success URL 리디렉션 (회귀)</li>
 </ul>
@@ -350,6 +413,8 @@
 <li>닉네임 15자 초과 → 400</li>
 <li>닉네임 중복 → 409</li>
 <li>이미 가입된 ssoSub으로 재등록 → 409</li>
+<li>이미 가입된 ssoSub으로 회원가입 전용 프로필 이미지 presigned 요청 → 409</li>
+<li>회원가입 전용 프로필 이미지 presigned 요청에서 비이미지 contentType → 400</li>
 <li>미가입 상태에서 <code>/posts</code> 접근 → 403</li>
 </ul>
 <h3>9.3 Edge Cases</h3>

--- a/docs/features/sso-registration-flow.md
+++ b/docs/features/sso-registration-flow.md
@@ -10,6 +10,7 @@
 ### 1.2 In Scope
 - `SsoCallbackPendingRegistration` 결과 타입 추가
 - `GET /auth/register/prefill` — JWT에서 pre-fill 가능한 값 반환
+- `POST /auth/register/profile-image/presigned` — 회원가입 전 프로필 이미지 업로드용 presigned URL 발급
 - `POST /auth/register` — 회원가입 완료 API
 - `Member` 도메인 필드 확장 (`name`, `phone`, `majorTrack`, `agreedAt`)
 - `ExternalIdentity` `major` 필드 추가
@@ -17,7 +18,6 @@
 - `MemberRegistrationService` auto-create 제거
 
 ### 1.3 Out of Scope
-- 프로필 이미지
 - 약관 버전 관리
 - 회원가입 후 이메일 인증
 
@@ -25,6 +25,7 @@
 - 미가입 INTERNAL 사용자가 SSO 콜백 후 register URL로 리디렉션된다.
 - `GET /auth/register/prefill`에서 name, studentNumber, major가 반환된다.
 - `POST /auth/register`로 회원가입 완료 후 정상 서비스 진입이 된다.
+- 회원가입 전 단계에서 프로필 이미지를 업로드해 `profileImageUrl`을 register 요청에 포함할 수 있다.
 - 미가입 상태에서 `/auth/register/**` 외 API 접근 시 `REGISTRATION_REQUIRED` 에러가 반환된다.
 - 기존 가입 사용자의 로그인 플로우는 그대로 동작한다.
 
@@ -102,6 +103,30 @@ Then:
 - `200 OK`가 반환된다.
 - 이후 일반 API 접근이 가능해진다.
 
+### Scenario C-1. 미가입 사용자가 회원가입 전 프로필 이미지 업로드용 presigned URL을 발급받는다
+Given:
+- SSO 토큰 쿠키가 세팅되어 있다.
+- DB에 해당 ssoSub의 멤버가 없다.
+- 업로드 파일 형식은 이미지다.
+
+When:
+- `POST /auth/register/profile-image/presigned`를 호출한다.
+
+Then:
+- 서버는 `members` 경로에 업로드할 presigned URL과 최종 `imageUrl`을 반환한다.
+- 프론트는 이 `imageUrl`을 최종 `POST /auth/register`의 `profileImageUrl`로 전달할 수 있다.
+
+### Scenario C-2. 이미 가입된 사용자는 회원가입 전용 프로필 이미지 presigned URL을 발급받을 수 없다
+Given:
+- SSO 토큰 쿠키가 세팅되어 있다.
+- DB에 해당 ssoSub의 멤버가 이미 존재한다.
+
+When:
+- `POST /auth/register/profile-image/presigned`를 호출한다.
+
+Then:
+- `409 MEMBER_ALREADY_EXISTS` 에러가 반환된다.
+
 ### Scenario D. 미가입 상태에서 일반 API에 접근한다
 Given:
 - SSO 토큰 쿠키가 세팅되어 있다.
@@ -140,6 +165,8 @@ Then:
 - FR-1: SSO 콜백 시 INTERNAL + 미가입이면 `SsoCallbackPendingRegistration`을 반환하고 register URL로 리디렉션한다.
 - FR-2: `GET /auth/register/prefill`은 SSO 쿠키를 검증하고 JWT에서 `name`, `studentNumber`, `major`를 반환한다.
 - FR-3: `POST /auth/register`는 `nickname`, `phone`, `agreedToTerms`를 받는다.
+- FR-3-1: `POST /auth/register/profile-image/presigned`는 `fileName`, `contentType`을 받고 presigned URL과 `imageUrl`을 반환한다.
+- FR-3-2: 회원가입 전용 프로필 이미지 presigned 발급은 `members` 폴더만 사용하며 클라이언트가 임의 폴더를 지정할 수 없다.
 - FR-4: `agreedToTerms`가 `false`이면 `400 INVALID_REQUEST`를 반환한다.
 - FR-5: `nickname`은 1~15자, 중복 불가.
 - FR-6: `phone`은 필수 입력값이다.
@@ -153,20 +180,24 @@ Then:
 
 ### 5.1 Preconditions
 - `GET /auth/register/prefill`, `POST /auth/register` 모두 유효한 SSO 토큰 쿠키 필요
+- `POST /auth/register/profile-image/presigned`도 유효한 SSO 토큰 쿠키 필요
 - `agreedToTerms == true`
 
 ### 5.2 Postconditions
 - Member 생성: `name`, `phone`, `nickname`, `studentNumber`, `majorTrack`, `agreedAt`, `ssoSub` 저장
 - `agreedAt = 서버 현재 시각`
 - 이후 `SsoAuthenticationFilter`에서 정상 멤버로 인식
+- 회원가입 전용 프로필 이미지 업로드는 member row를 생성하지 않는다.
 
 ### 5.3 Invariants
 - `name`, `studentNumber`, `major`는 서버가 JWT에서 직접 읽는다. 프론트 전달값을 신뢰하지 않는다.
+- `profileImageUrl`은 회원가입 전용 presigned 발급 API가 반환한 URL만 사용한다.
 - 한 ssoSub에 하나의 멤버만 존재한다.
 - `agreedToTerms == false`이면 회원가입이 완료되지 않는다.
 
 ### 5.4 Forbidden Rules
 - 프론트에서 `name`, `studentNumber`, `major`를 전달받아 저장하는 것
+- 기존 `POST /images/presigned`를 회원가입 전 단계에서 직접 호출하는 것
 - 미가입 상태에서 일반 API 접근 허용
 - auto-create로 닉네임을 자동 생성하는 것
 - soft delete 된 기존 회원을 새 회원가입 플로우로 다시 진입시키는 것
@@ -222,6 +253,29 @@ Then:
   - `409 MEMBER_ALREADY_EXISTS`: 이미 가입된 ssoSub
   - `409 DUPLICATE_NICKNAME`: 닉네임 중복
 
+**POST /auth/register/profile-image/presigned**
+- Auth: SSO 토큰 쿠키 필요
+- Request:
+```json
+{
+  "fileName": "profile.png",
+  "contentType": "image/png"
+}
+```
+- Response:
+```json
+{
+  "presignedUrl": "https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png?signature=...",
+  "imageUrl": "https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png"
+}
+```
+- Errors:
+  - `400 INVALID_REQUEST`: fileName 또는 contentType 누락
+  - `400 UNSUPPORTED_FILE_TYPE`: 허용되지 않은 이미지 형식
+  - `401 UNAUTHORIZED`: 쿠키 없음 또는 만료
+  - `403 FORBIDDEN`: EXTERNAL 사용자
+  - `409 MEMBER_ALREADY_EXISTS`: 이미 가입된 ssoSub
+
 ### 7.2 Persistence Contract
 - Member 테이블 신규 컬럼:
   - `name` VARCHAR NOT NULL
@@ -236,6 +290,7 @@ Then:
 ### 8.1 Security Constraints
 - `name`, `studentNumber`, `major`는 JWT에서만 읽는다.
 - register API는 SSO 쿠키 검증 없이 접근 불가.
+- 회원가입 전 프로필 이미지 업로드도 SSO 쿠키 검증 없이 접근 불가.
 
 ### 8.2 Technical Constraints
 - 기존 `Member.create()` 시그니처 변경 필요 → `MemberFixture` 업데이트 필요
@@ -248,6 +303,7 @@ Then:
 ### 9.1 Happy Path
 - 미가입 INTERNAL 콜백 → register URL 리디렉션
 - prefill 조회 성공
+- 회원가입 전용 프로필 이미지 presigned URL 발급 성공
 - 회원가입 완료 → 멤버 생성 확인
 - 기가입 사용자 콜백 → success URL 리디렉션 (회귀)
 
@@ -256,6 +312,8 @@ Then:
 - 닉네임 15자 초과 → 400
 - 닉네임 중복 → 409
 - 이미 가입된 ssoSub으로 재등록 → 409
+- 이미 가입된 ssoSub으로 회원가입 전용 프로필 이미지 presigned 요청 → 409
+- 회원가입 전용 프로필 이미지 presigned 요청에서 비이미지 contentType → 400
 - 미가입 상태에서 `/posts` 접근 → 403
 
 ### 9.3 Edge Cases

--- a/src/main/java/kr/ac/knu/comit/auth/controller/RegisterController.java
+++ b/src/main/java/kr/ac/knu/comit/auth/controller/RegisterController.java
@@ -3,10 +3,12 @@ package kr.ac.knu.comit.auth.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import kr.ac.knu.comit.auth.controller.api.RegisterControllerApi;
 import kr.ac.knu.comit.auth.dto.RegisterPrefillResponse;
+import kr.ac.knu.comit.auth.dto.RegisterProfileImagePresignedRequest;
 import kr.ac.knu.comit.auth.dto.RegisterRequest;
 import kr.ac.knu.comit.auth.service.AuthCookieManager;
 import kr.ac.knu.comit.auth.service.RegisterService;
 import kr.ac.knu.comit.global.exception.ApiResponse;
+import kr.ac.knu.comit.image.dto.PresignedUploadResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +24,19 @@ public class RegisterController implements RegisterControllerApi {
     public ResponseEntity<ApiResponse<RegisterPrefillResponse>> getPrefill(HttpServletRequest request) {
         return ResponseEntity.ok(
                 ApiResponse.success(registerService.getPrefill(authCookieManager.resolveTokenCookie(request)))
+        );
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<PresignedUploadResponse>> createProfileImagePresignedUpload(
+            RegisterProfileImagePresignedRequest request,
+            HttpServletRequest httpServletRequest
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(registerService.createProfileImagePresignedUpload(
+                        authCookieManager.resolveTokenCookie(httpServletRequest),
+                        request
+                ))
         );
     }
 

--- a/src/main/java/kr/ac/knu/comit/auth/controller/api/RegisterControllerApi.java
+++ b/src/main/java/kr/ac/knu/comit/auth/controller/api/RegisterControllerApi.java
@@ -3,6 +3,7 @@ package kr.ac.knu.comit.auth.controller.api;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import kr.ac.knu.comit.auth.dto.RegisterPrefillResponse;
+import kr.ac.knu.comit.auth.dto.RegisterProfileImagePresignedRequest;
 import kr.ac.knu.comit.auth.dto.RegisterRequest;
 import kr.ac.knu.comit.global.docs.annotation.ApiContract;
 import kr.ac.knu.comit.global.docs.annotation.ApiDoc;
@@ -10,6 +11,7 @@ import kr.ac.knu.comit.global.docs.annotation.ApiError;
 import kr.ac.knu.comit.global.docs.annotation.Example;
 import kr.ac.knu.comit.global.docs.annotation.FieldDesc;
 import kr.ac.knu.comit.global.exception.ApiResponse;
+import kr.ac.knu.comit.image.dto.PresignedUploadResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,6 +49,46 @@ public interface RegisterControllerApi {
     )
     @GetMapping("/prefill")
     ResponseEntity<ApiResponse<RegisterPrefillResponse>> getPrefill(HttpServletRequest request);
+
+    @ApiDoc(
+            summary = "회원가입 프로필 이미지 업로드용 presigned URL 발급",
+            description = "회원가입 전 단계에서 SSO 토큰 쿠키를 검증한 뒤 프로필 이미지 업로드용 presigned URL을 발급합니다.",
+            descriptions = {
+                    @FieldDesc(name = "fileName", value = "업로드할 파일 이름입니다."),
+                    @FieldDesc(name = "contentType", value = "업로드할 파일의 MIME 타입입니다."),
+                    @FieldDesc(name = "presignedUrl", value = "S3 업로드에 사용할 presigned URL입니다."),
+                    @FieldDesc(name = "imageUrl", value = "회원가입 요청의 profileImageUrl에 전달할 최종 이미지 URL입니다.")
+            },
+            errors = {
+                    @ApiError(code = "UNAUTHORIZED", when = "SSO 토큰 쿠키가 없거나 유효하지 않을 때"),
+                    @ApiError(code = "FORBIDDEN", when = "외부 사용자(EXTERNAL)가 호출할 때"),
+                    @ApiError(code = "MEMBER_ALREADY_EXISTS", when = "이미 가입된 회원이 호출할 때"),
+                    @ApiError(code = "UNSUPPORTED_FILE_TYPE", when = "지원하지 않는 파일 형식으로 요청할 때"),
+                    @ApiError(code = "INVALID_REQUEST", when = "요청 본문이 검증 규칙을 만족하지 않을 때")
+            },
+            example = @Example(
+                    request = """
+                            {
+                              "fileName": "profile.png",
+                              "contentType": "image/png"
+                            }
+                            """,
+                    response = """
+                            {
+                              "result": "SUCCESS",
+                              "data": {
+                                "presignedUrl": "https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png?signature=...",
+                                "imageUrl": "https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png"
+                              }
+                            }
+                            """
+            )
+    )
+    @PostMapping("/profile-image/presigned")
+    ResponseEntity<ApiResponse<PresignedUploadResponse>> createProfileImagePresignedUpload(
+            @RequestBody @Valid RegisterProfileImagePresignedRequest request,
+            HttpServletRequest httpServletRequest
+    );
 
     @ApiDoc(
             summary = "회원가입 완료",

--- a/src/main/java/kr/ac/knu/comit/auth/dto/RegisterProfileImagePresignedRequest.java
+++ b/src/main/java/kr/ac/knu/comit/auth/dto/RegisterProfileImagePresignedRequest.java
@@ -1,0 +1,12 @@
+package kr.ac.knu.comit.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterProfileImagePresignedRequest(
+        @NotBlank(message = "파일 이름을 입력해주세요.")
+        String fileName,
+
+        @NotBlank(message = "파일 형식을 입력해주세요.")
+        String contentType
+) {
+}

--- a/src/main/java/kr/ac/knu/comit/auth/service/RegisterService.java
+++ b/src/main/java/kr/ac/knu/comit/auth/service/RegisterService.java
@@ -1,6 +1,7 @@
 package kr.ac.knu.comit.auth.service;
 
 import kr.ac.knu.comit.auth.dto.RegisterPrefillResponse;
+import kr.ac.knu.comit.auth.dto.RegisterProfileImagePresignedRequest;
 import kr.ac.knu.comit.auth.dto.RegisterRequest;
 import kr.ac.knu.comit.auth.port.ExternalAuthClient;
 import kr.ac.knu.comit.auth.port.ExternalIdentity;
@@ -8,6 +9,9 @@ import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.CommonErrorCode;
 import kr.ac.knu.comit.global.exception.MemberErrorCode;
+import kr.ac.knu.comit.image.dto.PresignedUploadRequest;
+import kr.ac.knu.comit.image.dto.PresignedUploadResponse;
+import kr.ac.knu.comit.image.service.ImageService;
 import kr.ac.knu.comit.member.service.MemberRegistrationService;
 import kr.ac.knu.comit.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +27,7 @@ public class RegisterService {
     private final ExternalIdentityMapper externalIdentityMapper;
     private final MemberService memberService;
     private final MemberRegistrationService memberRegistrationService;
+    private final ImageService imageService;
 
     public RegisterPrefillResponse getPrefill(String token) {
         ExternalIdentity identity = verifyRegistrationIdentity(token);
@@ -51,6 +56,17 @@ public class RegisterService {
                 identity.studentNumber(),
                 identity.major(),
                 request.profileImageUrl()
+        );
+    }
+
+    public PresignedUploadResponse createProfileImagePresignedUpload(
+            String token,
+            RegisterProfileImagePresignedRequest request
+    ) {
+        ExternalIdentity identity = verifyRegistrationIdentity(token);
+        validateMemberDoesNotExist(identity.ssoSub());
+        return imageService.generatePresignedUrl(
+                new PresignedUploadRequest(request.fileName(), request.contentType(), "members")
         );
     }
 

--- a/src/main/java/kr/ac/knu/comit/post/controller/AdminPostController.java
+++ b/src/main/java/kr/ac/knu/comit/post/controller/AdminPostController.java
@@ -8,7 +8,9 @@ import kr.ac.knu.comit.post.controller.api.AdminPostControllerApi;
 import kr.ac.knu.comit.post.domain.BoardType;
 import kr.ac.knu.comit.post.dto.AdminCreatePostRequest;
 import kr.ac.knu.comit.post.dto.AdminCreatePostResponse;
+import kr.ac.knu.comit.post.dto.AdminPostDetailResponse;
 import kr.ac.knu.comit.post.dto.AdminPostPageResponse;
+import kr.ac.knu.comit.post.dto.AdminUpdatePostRequest;
 import kr.ac.knu.comit.post.dto.AdminVisibilityRequest;
 import kr.ac.knu.comit.post.service.AdminPostService;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +38,20 @@ public class AdminPostController implements AdminPostControllerApi {
         validateAdmin(principal);
         return ResponseEntity.ok(ApiResponse.success(
                 adminPostService.getPosts(boardType, pageable)));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<AdminPostDetailResponse>> getPost(Long postId, MemberPrincipal principal) {
+        validateAdmin(principal);
+        return ResponseEntity.ok(ApiResponse.success(adminPostService.getPost(postId)));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<Void>> updatePost(
+            Long postId, AdminUpdatePostRequest request, MemberPrincipal principal) {
+        validateAdmin(principal);
+        adminPostService.updatePost(postId, request);
+        return ResponseEntity.ok(ApiResponse.success());
     }
 
     @Override

--- a/src/main/java/kr/ac/knu/comit/post/controller/api/AdminPostControllerApi.java
+++ b/src/main/java/kr/ac/knu/comit/post/controller/api/AdminPostControllerApi.java
@@ -12,7 +12,9 @@ import kr.ac.knu.comit.global.exception.ApiResponse;
 import kr.ac.knu.comit.post.domain.BoardType;
 import kr.ac.knu.comit.post.dto.AdminCreatePostRequest;
 import kr.ac.knu.comit.post.dto.AdminCreatePostResponse;
+import kr.ac.knu.comit.post.dto.AdminPostDetailResponse;
 import kr.ac.knu.comit.post.dto.AdminPostPageResponse;
+import kr.ac.knu.comit.post.dto.AdminUpdatePostRequest;
 import kr.ac.knu.comit.post.dto.AdminVisibilityRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -113,6 +115,91 @@ public interface AdminPostControllerApi {
     ResponseEntity<ApiResponse<AdminPostPageResponse>> getPosts(
             @RequestParam(required = false) BoardType boardType,
             Pageable pageable,
+            @AuthenticatedMember MemberPrincipal principal
+    );
+
+    @ApiDoc(
+            summary = "게시글 상세 조회 (관리자)",
+            description = "관리자가 공지/이벤트/정보 게시글 상세 내용을 조회합니다. 수정 화면 진입에 필요한 본문, 태그, 이미지 URL을 포함합니다.",
+            descriptions = {
+                    @FieldDesc(name = "postId", value = "조회할 게시글 ID입니다."),
+                    @FieldDesc(name = "boardType", value = "게시판 유형입니다."),
+                    @FieldDesc(name = "title", value = "게시글 제목입니다."),
+                    @FieldDesc(name = "content", value = "게시글 본문입니다."),
+                    @FieldDesc(name = "tags", value = "태그 목록입니다."),
+                    @FieldDesc(name = "imageUrls", value = "첨부 이미지 URL 목록입니다."),
+                    @FieldDesc(name = "hiddenByAdmin", value = "관리자 숨김 여부입니다.")
+            },
+            errors = {
+                    @ApiError(code = "FORBIDDEN", when = "관리자 권한이 없는 사용자가 요청할 때"),
+                    @ApiError(code = "POST_NOT_FOUND", when = "존재하지 않는 게시글 ID로 요청할 때")
+            },
+            example = @Example(
+                    response = """
+                            {
+                              "result": "SUCCESS",
+                              "data": {
+                                "id": 42,
+                                "boardType": "EVENT",
+                                "title": "세미나 신청 안내",
+                                "content": "상세 일정 안내입니다.",
+                                "authorNickname": "관리자",
+                                "likeCount": 0,
+                                "viewCount": 10,
+                                "hiddenByAdmin": false,
+                                "tags": ["세미나", "행사"],
+                                "imageUrls": [],
+                                "createdAt": "2026-04-14T10:00:00",
+                                "updatedAt": "2026-04-14T10:05:00"
+                              }
+                            }
+                            """
+            )
+    )
+    @GetMapping("/{postId}")
+    ResponseEntity<ApiResponse<AdminPostDetailResponse>> getPost(
+            @PathVariable Long postId,
+            @AuthenticatedMember MemberPrincipal principal
+    );
+
+    @ApiDoc(
+            summary = "공지/이벤트/정보 게시글 수정 (관리자)",
+            description = "관리자가 NOTICE, EVENT, INFO 게시판의 게시글을 수정합니다. 수정 시 게시판 유형, 제목, 본문, 태그, 이미지 URL을 통째로 교체합니다.",
+            descriptions = {
+                    @FieldDesc(name = "postId", value = "수정할 게시글 ID입니다."),
+                    @FieldDesc(name = "boardType", value = "게시판 유형입니다. NOTICE, EVENT, INFO 중 하나만 허용됩니다."),
+                    @FieldDesc(name = "title", value = "수정할 게시글 제목입니다."),
+                    @FieldDesc(name = "content", value = "수정할 게시글 내용입니다."),
+                    @FieldDesc(name = "tags", value = "태그 목록입니다. 생략 가능합니다."),
+                    @FieldDesc(name = "imageUrls", value = "첨부 이미지 URL 목록입니다. 생략 가능합니다.")
+            },
+            errors = {
+                    @ApiError(code = "FORBIDDEN", when = "관리자 권한이 없는 사용자가 요청할 때"),
+                    @ApiError(code = "FORBIDDEN_BOARD_TYPE", when = "NOTICE, EVENT, INFO 외 boardType으로 요청할 때"),
+                    @ApiError(code = "POST_NOT_FOUND", when = "존재하지 않는 게시글 ID로 요청할 때"),
+                    @ApiError(code = "INVALID_REQUEST", when = "요청 본문이 검증 규칙을 만족하지 않을 때")
+            },
+            example = @Example(
+                    request = """
+                            {
+                              "boardType": "EVENT",
+                              "title": "세미나 신청 안내 수정",
+                              "content": "수정된 상세 일정 안내입니다.",
+                              "tags": ["세미나", "행사"],
+                              "imageUrls": []
+                            }
+                            """,
+                    response = """
+                            {
+                              "result": "SUCCESS"
+                            }
+                            """
+            )
+    )
+    @PatchMapping("/{postId}")
+    ResponseEntity<ApiResponse<Void>> updatePost(
+            @PathVariable Long postId,
+            @Valid @RequestBody AdminUpdatePostRequest request,
             @AuthenticatedMember MemberPrincipal principal
     );
 

--- a/src/main/java/kr/ac/knu/comit/post/domain/Post.java
+++ b/src/main/java/kr/ac/knu/comit/post/domain/Post.java
@@ -94,6 +94,15 @@ public class Post {
      * @implNote 태그는 통째로 교체한다. 기존 row 정리는 orphan removal에 맡긴다.
      */
     public void update(String title, String content, List<String> tagNames, List<String> imageUrls) {
+        applyEditableFields(title, content, tagNames, imageUrls);
+    }
+
+    public void updateByAdmin(BoardType boardType, String title, String content, List<String> tagNames, List<String> imageUrls) {
+        this.boardType = boardType;
+        applyEditableFields(title, content, tagNames, imageUrls);
+    }
+
+    private void applyEditableFields(String title, String content, List<String> tagNames, List<String> imageUrls) {
         List<String> normalizedTagNames = normalizeTagNames(tagNames);
         List<String> normalizedImageUrls = normalizeImageUrls(imageUrls);
         validateTitle(title);

--- a/src/main/java/kr/ac/knu/comit/post/dto/AdminPostDetailResponse.java
+++ b/src/main/java/kr/ac/knu/comit/post/dto/AdminPostDetailResponse.java
@@ -1,0 +1,41 @@
+package kr.ac.knu.comit.post.dto;
+
+import kr.ac.knu.comit.post.domain.Post;
+import kr.ac.knu.comit.post.domain.PostImage;
+import kr.ac.knu.comit.post.domain.PostTag;
+import kr.ac.knu.comit.post.domain.BoardType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AdminPostDetailResponse(
+        Long id,
+        BoardType boardType,
+        String title,
+        String content,
+        String authorNickname,
+        int likeCount,
+        int viewCount,
+        boolean hiddenByAdmin,
+        List<String> tags,
+        List<String> imageUrls,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static AdminPostDetailResponse from(Post post) {
+        return new AdminPostDetailResponse(
+                post.getId(),
+                post.getBoardType(),
+                post.getTitle(),
+                post.getContent(),
+                post.getMember().getDisplayNickname(),
+                post.getLikeCount(),
+                post.getViewCount(),
+                post.isHiddenByAdmin(),
+                post.getTags().stream().map(PostTag::getName).toList(),
+                post.getImages().stream().map(PostImage::getImageUrl).toList(),
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/kr/ac/knu/comit/post/dto/AdminUpdatePostRequest.java
+++ b/src/main/java/kr/ac/knu/comit/post/dto/AdminUpdatePostRequest.java
@@ -1,0 +1,44 @@
+package kr.ac.knu.comit.post.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import kr.ac.knu.comit.post.domain.BoardType;
+import kr.ac.knu.comit.post.domain.PostConstraints;
+
+import java.util.List;
+
+public record AdminUpdatePostRequest(
+        @NotNull(message = "게시판 유형을 선택해주세요.")
+        BoardType boardType,
+
+        @NotBlank(message = "제목을 입력해주세요.")
+        @Size(max = PostConstraints.TITLE_MAX_LENGTH,
+                message = "제목은 " + PostConstraints.TITLE_MAX_LENGTH + "자 이하이어야 합니다.")
+        String title,
+
+        @NotBlank(message = "내용을 입력해주세요.")
+        @Size(max = PostConstraints.CONTENT_MAX_LENGTH,
+                message = "내용은 " + PostConstraints.CONTENT_MAX_LENGTH + "자 이하이어야 합니다.")
+        String content,
+
+        @Size(max = PostConstraints.TAG_MAX_COUNT,
+                message = "태그는 최대 " + PostConstraints.TAG_MAX_COUNT + "개까지 입력할 수 있습니다.")
+        List<
+                @NotBlank(message = "태그는 비어 있을 수 없습니다.")
+                @Size(max = PostConstraints.TAG_NAME_MAX_LENGTH,
+                        message = "태그는 " + PostConstraints.TAG_NAME_MAX_LENGTH + "자 이하이어야 합니다.")
+                String> tags,
+
+        @Size(max = PostConstraints.IMAGE_MAX_COUNT,
+                message = "이미지는 최대 " + PostConstraints.IMAGE_MAX_COUNT + "개까지 첨부할 수 있습니다.")
+        List<String> imageUrls
+) {
+    public List<String> tags() {
+        return tags == null ? List.of() : tags;
+    }
+
+    public List<String> imageUrls() {
+        return imageUrls == null ? List.of() : imageUrls;
+    }
+}

--- a/src/main/java/kr/ac/knu/comit/post/service/AdminPostService.java
+++ b/src/main/java/kr/ac/knu/comit/post/service/AdminPostService.java
@@ -9,7 +9,9 @@ import kr.ac.knu.comit.post.domain.Post;
 import kr.ac.knu.comit.post.domain.PostRepository;
 import kr.ac.knu.comit.post.dto.AdminCreatePostRequest;
 import kr.ac.knu.comit.post.dto.AdminCreatePostResponse;
+import kr.ac.knu.comit.post.dto.AdminPostDetailResponse;
 import kr.ac.knu.comit.post.dto.AdminPostPageResponse;
+import kr.ac.knu.comit.post.dto.AdminUpdatePostRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,9 +34,7 @@ public class AdminPostService {
 
     @Transactional
     public AdminCreatePostResponse createPost(Long adminMemberId, AdminCreatePostRequest request) {
-        if (!ADMIN_ONLY_BOARD_TYPES.contains(request.boardType())) {
-            throw new BusinessException(PostErrorCode.FORBIDDEN_BOARD_TYPE);
-        }
+        validateAdminBoardType(request.boardType());
         Member author = memberService.findMemberOrThrow(adminMemberId);
         Post post = Post.create(author, request.boardType(), request.title(),
                 request.content(), request.tags(), request.imageUrls());
@@ -44,6 +44,26 @@ public class AdminPostService {
     public AdminPostPageResponse getPosts(BoardType boardType, Pageable pageable) {
         Page<Post> postPage = postRepository.findAllActiveForAdmin(boardType, pageable);
         return AdminPostPageResponse.from(postPage);
+    }
+
+    public AdminPostDetailResponse getPost(Long postId) {
+        Post post = findPostOrThrow(postId);
+        validateAdminBoardType(post.getBoardType());
+        return AdminPostDetailResponse.from(post);
+    }
+
+    @Transactional
+    public void updatePost(Long postId, AdminUpdatePostRequest request) {
+        Post post = findPostOrThrow(postId);
+        validateAdminBoardType(post.getBoardType());
+        validateAdminBoardType(request.boardType());
+        post.updateByAdmin(
+                request.boardType(),
+                request.title(),
+                request.content(),
+                request.tags(),
+                request.imageUrls()
+        );
     }
 
     @Transactional
@@ -67,5 +87,11 @@ public class AdminPostService {
     private Post findPostOrThrow(Long postId) {
         return postRepository.findActiveByIdForAdmin(postId)
                 .orElseThrow(() -> new BusinessException(PostErrorCode.POST_NOT_FOUND));
+    }
+
+    private void validateAdminBoardType(BoardType boardType) {
+        if (!ADMIN_ONLY_BOARD_TYPES.contains(boardType)) {
+            throw new BusinessException(PostErrorCode.FORBIDDEN_BOARD_TYPE);
+        }
     }
 }

--- a/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
@@ -45,6 +45,7 @@ import kr.ac.knu.comit.post.controller.PostController;
 import kr.ac.knu.comit.post.domain.BoardType;
 import kr.ac.knu.comit.post.domain.PostConstraints;
 import kr.ac.knu.comit.post.service.AdminPostService;
+import kr.ac.knu.comit.post.dto.AdminPostDetailResponse;
 import kr.ac.knu.comit.post.dto.HotPostListResponse;
 import kr.ac.knu.comit.post.dto.HotPostResponse;
 import kr.ac.knu.comit.post.dto.PostCursorPageResponse;
@@ -535,6 +536,38 @@ class AuthenticatedApiWebTest {
     }
 
     @Test
+    void returnsForbiddenWhenNonAdminRequestsAdminPostDetail() throws Exception {
+        mockMvc.perform(get("/admin/posts/1")
+                        .header("X-Member-Sub", "member-1")
+                        .header("X-Member-Name", "student")
+                        .header("X-Member-Role", "STUDENT"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.type").value("/problems/common/forbidden"))
+                .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"));
+    }
+
+    @Test
+    void returnsForbiddenWhenNonAdminUpdatesAdminPost() throws Exception {
+        mockMvc.perform(patch("/admin/posts/1")
+                        .header("X-Member-Sub", "member-1")
+                        .header("X-Member-Name", "student")
+                        .header("X-Member-Role", "STUDENT")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "boardType": "EVENT",
+                                  "title": "수정 제목",
+                                  "content": "수정 본문",
+                                  "tags": [],
+                                  "imageUrls": []
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.type").value("/problems/common/forbidden"))
+                .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"));
+    }
+
+    @Test
     void returnsForbiddenWhenNonAdminRequestsAdminCommentList() throws Exception {
         // when & then
         // 관리자 권한이 아니면 댓글 관리자 API 접근이 거부되어야 한다.
@@ -584,6 +617,56 @@ class AuthenticatedApiWebTest {
                         .header("X-Member-Sub", "member-1")
                         .header("X-Member-Name", "admin")
                         .header("X-Member-Role", "ADMIN"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("SUCCESS"));
+    }
+
+    @Test
+    void returnsAdminPostDetailWhenAdminRequestsIt() throws Exception {
+        given(adminPostService.getPost(42L)).willReturn(
+                new AdminPostDetailResponse(
+                        42L,
+                        BoardType.EVENT,
+                        "세미나 신청 안내",
+                        "상세 일정 안내입니다.",
+                        "관리자",
+                        0,
+                        10,
+                        false,
+                        List.of("세미나", "행사"),
+                        List.of("https://cdn.example.com/event-42.png"),
+                        LocalDateTime.parse("2026-04-14T10:00:00"),
+                        LocalDateTime.parse("2026-04-14T10:05:00")
+                )
+        );
+
+        mockMvc.perform(get("/admin/posts/42")
+                        .header("X-Member-Sub", "member-1")
+                        .header("X-Member-Name", "admin")
+                        .header("X-Member-Role", "ADMIN"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.boardType").value("EVENT"))
+                .andExpect(jsonPath("$.data.content").value("상세 일정 안내입니다."))
+                .andExpect(jsonPath("$.data.tags[0]").value("세미나"));
+    }
+
+    @Test
+    void updatesAdminPostWhenAdminRequestsIt() throws Exception {
+        mockMvc.perform(patch("/admin/posts/42")
+                        .header("X-Member-Sub", "member-1")
+                        .header("X-Member-Name", "admin")
+                        .header("X-Member-Role", "ADMIN")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "boardType": "EVENT",
+                                  "title": "수정 제목",
+                                  "content": "수정 본문",
+                                  "tags": ["세미나"],
+                                  "imageUrls": []
+                                }
+                                """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result").value("SUCCESS"));
     }

--- a/src/test/java/kr/ac/knu/comit/api/SsoAuthWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/SsoAuthWebTest.java
@@ -28,6 +28,8 @@ import kr.ac.knu.comit.global.auth.MemberArgumentResolver;
 import kr.ac.knu.comit.global.auth.SsoAuthenticationFilter;
 import kr.ac.knu.comit.global.config.WebMvcConfig;
 import kr.ac.knu.comit.global.exception.GlobalExceptionHandler;
+import kr.ac.knu.comit.image.dto.PresignedUploadResponse;
+import kr.ac.knu.comit.image.service.ImageService;
 import kr.ac.knu.comit.member.controller.MemberController;
 import kr.ac.knu.comit.member.domain.Member;
 import kr.ac.knu.comit.member.dto.MemberProfileResponse;
@@ -91,6 +93,9 @@ class SsoAuthWebTest {
 
     @MockitoBean
     private MemberRegistrationService memberRegistrationService;
+
+    @MockitoBean
+    private ImageService imageService;
 
     @BeforeEach
     void setUp() {
@@ -237,6 +242,31 @@ class SsoAuthWebTest {
                 .anySatisfy(cookie -> assertThat(cookie).contains("comit-redirect-uri=").contains("Max-Age=0"));
         assertThat(result.getResponse().getHeaders("Set-Cookie"))
                 .noneSatisfy(cookie -> assertThat(cookie).contains("COMIT_SSO_TOKEN="));
+    }
+
+    @Test
+    @DisplayName("미가입 회원은 회원가입 전용 프로필 이미지 presigned URL을 발급받을 수 있다")
+    void createsProfileImagePresignedUploadForPendingRegistration() throws Exception {
+        given(memberService.hasAnyMember("sso-sub-1")).willReturn(false);
+        given(imageService.generatePresignedUrl(any())).willReturn(
+                new PresignedUploadResponse(
+                        "https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png?signature=test",
+                        "https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png"
+                )
+        );
+
+        mockMvc.perform(post("/auth/register/profile-image/presigned")
+                        .cookie(new jakarta.servlet.http.Cookie("COMIT_SSO_TOKEN", "token-123"))
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "fileName": "profile.png",
+                                  "contentType": "image/png"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.imageUrl").value("https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png"));
     }
 
     @Test

--- a/src/test/java/kr/ac/knu/comit/auth/service/RegisterServiceTest.java
+++ b/src/test/java/kr/ac/knu/comit/auth/service/RegisterServiceTest.java
@@ -2,11 +2,13 @@ package kr.ac.knu.comit.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import java.util.Optional;
 import kr.ac.knu.comit.auth.dto.RegisterPrefillResponse;
+import kr.ac.knu.comit.auth.dto.RegisterProfileImagePresignedRequest;
 import kr.ac.knu.comit.auth.dto.RegisterRequest;
 import kr.ac.knu.comit.auth.port.ExternalAuthClient;
 import kr.ac.knu.comit.auth.port.ExternalIdentity;
@@ -14,6 +16,8 @@ import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.CommonErrorCode;
 import kr.ac.knu.comit.global.exception.MemberErrorCode;
+import kr.ac.knu.comit.image.dto.PresignedUploadResponse;
+import kr.ac.knu.comit.image.service.ImageService;
 import kr.ac.knu.comit.member.service.MemberRegistrationService;
 import kr.ac.knu.comit.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +42,9 @@ class RegisterServiceTest {
 
     @Mock
     private MemberRegistrationService memberRegistrationService;
+
+    @Mock
+    private ImageService imageService;
 
     @InjectMocks
     private RegisterService registerService;
@@ -128,6 +135,30 @@ class RegisterServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(MemberErrorCode.MEMBER_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("회원가입 전용 프로필 이미지 presigned URL 발급은 가입 전 사용자에게만 허용된다")
+    void createsProfileImagePresignedUploadForPendingRegistration() {
+        ExternalIdentity identity = identity();
+        given(externalAuthClient.verify("token-123")).willReturn(identity);
+        given(externalIdentityMapper.toPrincipal(identity)).willReturn(principal());
+        given(memberService.hasAnyMember("sso-sub-1")).willReturn(false);
+        given(imageService.generatePresignedUrl(any())).willReturn(
+                new PresignedUploadResponse(
+                        "https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png?signature=test",
+                        "https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png"
+                )
+        );
+
+        PresignedUploadResponse response = registerService.createProfileImagePresignedUpload(
+                "token-123",
+                new RegisterProfileImagePresignedRequest("profile.png", "image/png")
+        );
+
+        assertThat(response.imageUrl()).isEqualTo("https://bucket.s3.ap-northeast-2.amazonaws.com/members/profile.png");
+        assertThat(response.presignedUrl()).contains("signature=test");
+        then(imageService).should().generatePresignedUrl(any());
     }
 
     private ExternalIdentity identity() {

--- a/src/test/java/kr/ac/knu/comit/global/docs/ApiDocGeneratorTest.java
+++ b/src/test/java/kr/ac/knu/comit/global/docs/ApiDocGeneratorTest.java
@@ -71,6 +71,10 @@ class ApiDocGeneratorTest {
         assertThat(authHtml).contains("/auth/sso/login");
         assertThat(authHtml).contains("/auth/sso/callback");
 
+        String registerHtml = Files.readString(tempDir.resolve("auth/RegisterControllerApi.html"));
+        assertThat(registerHtml).contains("/auth/register/profile-image/presigned");
+        assertThat(registerHtml).contains("회원가입 프로필 이미지 업로드용 presigned URL 발급");
+
         String mainHtml = Files.readString(tempDir.resolve("main/MainControllerApi.html"));
         assertThat(mainHtml).contains("/main");
         assertThat(mainHtml).contains("qna");
@@ -81,5 +85,10 @@ class ApiDocGeneratorTest {
         String adminMemberHtml = Files.readString(tempDir.resolve("member/AdminMemberControllerApi.html"));
         assertThat(adminMemberHtml).contains("회원 삭제 (관리자)");
         assertThat(adminMemberHtml).contains("탈퇴한 사용자");
+
+        String adminPostHtml = Files.readString(tempDir.resolve("post/AdminPostControllerApi.html"));
+        assertThat(adminPostHtml).contains("/admin/posts/{postId}");
+        assertThat(adminPostHtml).contains("게시글 상세 조회 (관리자)");
+        assertThat(adminPostHtml).contains("공지/이벤트/정보 게시글 수정 (관리자)");
     }
 }


### PR DESCRIPTION
## 변경 사항
- 회원가입 전용 프로필 이미지 presigned URL 발급 API를 추가했습니다.
- SSO 회원가입 플로우 문서에 프로필 이미지 업로드 계약을 반영했습니다.
- 관리자 게시글 상세 조회/수정 API를 추가해 공지·이벤트·정보 게시글 CRUD를 닫았습니다.
- 관련 웹 테스트와 API 문서 생성 검증을 함께 갱신했습니다.

## 검증
- ./gradlew test generateApiDocs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now upload a profile image during SSO registration using a presigned URL before completing signup.
  * Admins can now view detailed post information and edit posts, including changing post types.

* **Documentation**
  * Updated API documentation and registration flow specifications for the new profile image upload functionality.
  * Extended test coverage for new admin post management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->