### PR TITLE
Feat/#76 admin 접속 분기 구현

### DIFF
--- a/src/main/java/kr/ac/knu/comit/auth/config/AdminEmailProperties.java
+++ b/src/main/java/kr/ac/knu/comit/auth/config/AdminEmailProperties.java
@@ -1,0 +1,32 @@
+package kr.ac.knu.comit.auth.config;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "comit.auth")
+public class AdminEmailProperties {
+
+    /**
+     * 관리자 이메일 목록. 해당 이메일로 인증 시 자동 회원가입 후 ADMIN 권한이 부여된다.
+     * 환경변수 COMIT_AUTH_ADMIN_EMAILS 에 콤마(,)로 구분하여 입력한다.
+     */
+    private List<String> adminEmails = List.of();
+
+    public boolean isAdminEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return false;
+        }
+        Set<String> normalized = adminEmails.stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+        return normalized.contains(email.strip().toLowerCase());
+    }
+}

--- a/src/main/java/kr/ac/knu/comit/auth/service/ExternalIdentityMapper.java
+++ b/src/main/java/kr/ac/knu/comit/auth/service/ExternalIdentityMapper.java
@@ -1,19 +1,37 @@
 package kr.ac.knu.comit.auth.service;
 
+import kr.ac.knu.comit.auth.config.AdminEmailProperties;
 import kr.ac.knu.comit.auth.port.ExternalIdentity;
 import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.CommonErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class ExternalIdentityMapper {
+
+    static final String ADMIN_DISPLAY = "관리자";
+
+    private final AdminEmailProperties adminEmailProperties;
 
     public MemberPrincipal toPrincipal(ExternalIdentity identity) {
         return toPrincipal(null, identity);
     }
 
     public MemberPrincipal toPrincipal(Long memberId, ExternalIdentity identity) {
+        if (adminEmailProperties.isAdminEmail(identity.email())) {
+            return new MemberPrincipal(
+                    memberId,
+                    requiredString(identity.ssoSub()),
+                    ADMIN_DISPLAY,
+                    ADMIN_DISPLAY,
+                    ADMIN_DISPLAY,
+                    MemberPrincipal.UserType.CSE_STUDENT,
+                    MemberPrincipal.MemberRole.ADMIN
+            );
+        }
         return new MemberPrincipal(
                 memberId,
                 requiredString(identity.ssoSub()),

--- a/src/main/java/kr/ac/knu/comit/auth/service/SsoAuthService.java
+++ b/src/main/java/kr/ac/knu/comit/auth/service/SsoAuthService.java
@@ -2,6 +2,7 @@ package kr.ac.knu.comit.auth.service;
 
 import java.net.URI;
 import java.util.UUID;
+import kr.ac.knu.comit.auth.config.AdminEmailProperties;
 import kr.ac.knu.comit.auth.config.ComitSsoProperties;
 import kr.ac.knu.comit.auth.dto.SsoCallbackPendingRegistration;
 import kr.ac.knu.comit.auth.dto.SsoCallbackRejected;
@@ -13,6 +14,7 @@ import kr.ac.knu.comit.auth.port.ExternalIdentity;
 import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.CommonErrorCode;
+import kr.ac.knu.comit.member.service.MemberRegistrationService;
 import kr.ac.knu.comit.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,11 +26,16 @@ import org.springframework.web.util.UriComponentsBuilder;
 @RequiredArgsConstructor
 public class SsoAuthService {
 
+    private static final String ADMIN_DISPLAY = "관리자";
+    private static final String ADMIN_PHONE_PLACEHOLDER = "000-000-0000";
+
     private final ComitSsoProperties ssoProperties;
     private final ExternalAuthClient externalAuthClient;
     private final AuthCookieManager authCookieManager;
     private final ExternalIdentityMapper externalIdentityMapper;
     private final MemberService memberService;
+    private final MemberRegistrationService memberRegistrationService;
+    private final AdminEmailProperties adminEmailProperties;
 
     public SsoLoginStart startLogin() {
         return startLogin(null);
@@ -69,12 +76,24 @@ public class SsoAuthService {
         }
 
         if (!memberService.hasActiveMember(principal.ssoSub())) {
-            return new SsoCallbackPendingRegistration(
-                    resolveRegisterUrl(storedRedirectUri),
-                    authCookieManager.createTokenCookie(token),
-                    authCookieManager.clearStateCookie(),
-                    authCookieManager.clearRedirectUriCookie()
-            );
+            if (adminEmailProperties.isAdminEmail(identity.email())) {
+                memberRegistrationService.register(
+                        identity.ssoSub(),
+                        ADMIN_DISPLAY,
+                        ADMIN_PHONE_PLACEHOLDER,
+                        adminNickname(identity.ssoSub()),
+                        null,
+                        null,
+                        null
+                );
+            } else {
+                return new SsoCallbackPendingRegistration(
+                        resolveRegisterUrl(storedRedirectUri),
+                        authCookieManager.createTokenCookie(token),
+                        authCookieManager.clearStateCookie(),
+                        authCookieManager.clearRedirectUriCookie()
+                );
+            }
         }
 
         return new SsoCallbackSuccess(
@@ -216,5 +235,11 @@ public class SsoAuthService {
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private static String adminNickname(String ssoSub) {
+        String cleaned = ssoSub.replaceAll("[^a-zA-Z0-9]", "");
+        String suffix = cleaned.length() >= 6 ? cleaned.substring(0, 6) : cleaned;
+        return "관리자-" + suffix;
     }
 }

--- a/src/main/java/kr/ac/knu/comit/auth/service/SsoAuthService.java
+++ b/src/main/java/kr/ac/knu/comit/auth/service/SsoAuthService.java
@@ -14,6 +14,7 @@ import kr.ac.knu.comit.auth.port.ExternalIdentity;
 import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.CommonErrorCode;
+import kr.ac.knu.comit.global.exception.MemberErrorCode;
 import kr.ac.knu.comit.member.service.MemberRegistrationService;
 import kr.ac.knu.comit.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -77,15 +78,21 @@ public class SsoAuthService {
 
         if (!memberService.hasActiveMember(principal.ssoSub())) {
             if (adminEmailProperties.isAdminEmail(identity.email())) {
-                memberRegistrationService.register(
-                        identity.ssoSub(),
-                        ADMIN_DISPLAY,
-                        ADMIN_PHONE_PLACEHOLDER,
-                        adminNickname(identity.ssoSub()),
-                        null,
-                        null,
-                        null
-                );
+                try {
+                    memberRegistrationService.register(
+                            identity.ssoSub(),
+                            ADMIN_DISPLAY,
+                            ADMIN_PHONE_PLACEHOLDER,
+                            adminNickname(identity.ssoSub()),
+                            null,
+                            null,
+                            null
+                    );
+                } catch (BusinessException e) {
+                    if (e.getErrorCode() != MemberErrorCode.MEMBER_ALREADY_EXISTS) {
+                        throw e;
+                    }
+                }
             } else {
                 return new SsoCallbackPendingRegistration(
                         resolveRegisterUrl(storedRedirectUri),

--- a/src/main/java/kr/ac/knu/comit/global/auth/MemberAuthenticationFilter.java
+++ b/src/main/java/kr/ac/knu/comit/global/auth/MemberAuthenticationFilter.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import kr.ac.knu.comit.auth.config.AdminEmailProperties;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.MemberErrorCode;
+
 import kr.ac.knu.comit.member.domain.Member;
 import kr.ac.knu.comit.member.service.MemberRegistrationService;
 import kr.ac.knu.comit.member.service.MemberService;
@@ -73,15 +74,21 @@ public class MemberAuthenticationFilter extends OncePerRequestFilter {
             Optional<Member> memberOptional = memberService.findBySso(provisionalPrincipal);
             if (memberOptional.isEmpty()) {
                 if (isAdmin) {
-                    memberRegistrationService.register(
-                            ssoSub,
-                            ADMIN_DISPLAY,
-                            ADMIN_PHONE_PLACEHOLDER,
-                            adminNickname(ssoSub),
-                            null,
-                            null,
-                            null
-                    );
+                    try {
+                        memberRegistrationService.register(
+                                ssoSub,
+                                ADMIN_DISPLAY,
+                                ADMIN_PHONE_PLACEHOLDER,
+                                adminNickname(ssoSub),
+                                null,
+                                null,
+                                null
+                        );
+                    } catch (BusinessException e) {
+                        if (e.getErrorCode() != MemberErrorCode.MEMBER_ALREADY_EXISTS) {
+                            throw e;
+                        }
+                    }
                     memberOptional = memberService.findBySso(provisionalPrincipal);
                 } else {
                     throw new BusinessException(MemberErrorCode.REGISTRATION_REQUIRED);

--- a/src/main/java/kr/ac/knu/comit/global/auth/MemberAuthenticationFilter.java
+++ b/src/main/java/kr/ac/knu/comit/global/auth/MemberAuthenticationFilter.java
@@ -6,9 +6,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
+
+import kr.ac.knu.comit.auth.config.AdminEmailProperties;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.MemberErrorCode;
 import kr.ac.knu.comit.member.domain.Member;
+import kr.ac.knu.comit.member.service.MemberRegistrationService;
 import kr.ac.knu.comit.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,8 +31,13 @@ public class MemberAuthenticationFilter extends OncePerRequestFilter {
     private static final String USER_TYPE_HEADER = "X-Member-User-Type";
     private static final String ROLE_HEADER = "X-Member-Role";
 
+    private static final String ADMIN_DISPLAY = "관리자";
+    private static final String ADMIN_PHONE_PLACEHOLDER = "000-000-0000";
+
     private final MemberService memberService;
+    private final MemberRegistrationService memberRegistrationService;
     private final HandlerExceptionResolver handlerExceptionResolver;
+    private final AdminEmailProperties adminEmailProperties;
 
     @Override
     protected void doFilterInternal(
@@ -48,20 +56,36 @@ public class MemberAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
+        String email = trimToNull(request.getHeader(EMAIL_HEADER));
+        boolean isAdmin = adminEmailProperties.isAdminEmail(email);
+
         MemberPrincipal provisionalPrincipal = new MemberPrincipal(
                 null,
                 ssoSub,
-                defaultName(request),
-                trimToNull(request.getHeader(EMAIL_HEADER)),
+                isAdmin ? ADMIN_DISPLAY : defaultName(request),
+                isAdmin ? ADMIN_DISPLAY : email,
                 trimToNull(request.getHeader(STUDENT_NUMBER_HEADER)),
                 parseUserType(request.getHeader(USER_TYPE_HEADER)),
-                parseRole(request.getHeader(ROLE_HEADER))
+                isAdmin ? MemberPrincipal.MemberRole.ADMIN : parseRole(request.getHeader(ROLE_HEADER))
         );
 
         try {
             Optional<Member> memberOptional = memberService.findBySso(provisionalPrincipal);
             if (memberOptional.isEmpty()) {
-                throw new BusinessException(MemberErrorCode.REGISTRATION_REQUIRED);
+                if (isAdmin) {
+                    memberRegistrationService.register(
+                            ssoSub,
+                            ADMIN_DISPLAY,
+                            ADMIN_PHONE_PLACEHOLDER,
+                            adminNickname(ssoSub),
+                            null,
+                            null,
+                            null
+                    );
+                    memberOptional = memberService.findBySso(provisionalPrincipal);
+                } else {
+                    throw new BusinessException(MemberErrorCode.REGISTRATION_REQUIRED);
+                }
             }
 
             Member member = memberOptional.get();
@@ -131,5 +155,11 @@ public class MemberAuthenticationFilter extends OncePerRequestFilter {
         }
         String normalized = value.trim();
         return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static String adminNickname(String ssoSub) {
+        String cleaned = ssoSub.replaceAll("[^a-zA-Z0-9]", "");
+        String suffix = cleaned.length() >= 6 ? cleaned.substring(0, 6) : cleaned;
+        return "관리자-" + suffix;
     }
 }

--- a/src/main/java/kr/ac/knu/comit/global/auth/SsoAuthenticationFilter.java
+++ b/src/main/java/kr/ac/knu/comit/global/auth/SsoAuthenticationFilter.java
@@ -6,6 +6,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
+
+import kr.ac.knu.comit.auth.config.AdminEmailProperties;
 import kr.ac.knu.comit.auth.port.ExternalAuthClient;
 import kr.ac.knu.comit.auth.port.ExternalIdentity;
 import kr.ac.knu.comit.auth.service.AuthCookieManager;
@@ -13,6 +15,7 @@ import kr.ac.knu.comit.auth.service.ExternalIdentityMapper;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.MemberErrorCode;
 import kr.ac.knu.comit.member.domain.Member;
+import kr.ac.knu.comit.member.service.MemberRegistrationService;
 import kr.ac.knu.comit.member.service.MemberService;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
@@ -31,10 +34,15 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class SsoAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final String ADMIN_DISPLAY = "관리자";
+    private static final String ADMIN_PHONE_PLACEHOLDER = "000-000-0000";
+
     private final AuthCookieManager authCookieManager;
     private final ExternalAuthClient externalAuthClient;
     private final ExternalIdentityMapper externalIdentityMapper;
     private final MemberService memberService;
+    private final MemberRegistrationService memberRegistrationService;
+    private final AdminEmailProperties adminEmailProperties;
     private final HandlerExceptionResolver handlerExceptionResolver;
 
     @Override
@@ -60,7 +68,20 @@ public class SsoAuthenticationFilter extends OncePerRequestFilter {
 
             Optional<Member> memberOptional = memberService.findBySso(provisionalPrincipal);
             if (memberOptional.isEmpty()) {
-                throw new BusinessException(MemberErrorCode.REGISTRATION_REQUIRED);
+                if (adminEmailProperties.isAdminEmail(identity.email())) {
+                    memberRegistrationService.register(
+                            identity.ssoSub(),
+                            ADMIN_DISPLAY,
+                            ADMIN_PHONE_PLACEHOLDER,
+                            adminNickname(identity.ssoSub()),
+                            null,
+                            null,
+                            null
+                    );
+                    memberOptional = memberService.findBySso(provisionalPrincipal);
+                } else {
+                    throw new BusinessException(MemberErrorCode.REGISTRATION_REQUIRED);
+                }
             }
 
             Member member = memberOptional.get();
@@ -95,5 +116,11 @@ public class SsoAuthenticationFilter extends OncePerRequestFilter {
 
     private boolean isAuthPath(String servletPath, String path) {
         return servletPath.equals(path) || servletPath.startsWith(path + "/");
+    }
+
+    private static String adminNickname(String ssoSub) {
+        String cleaned = ssoSub.replaceAll("[^a-zA-Z0-9]", "");
+        String suffix = cleaned.length() >= 6 ? cleaned.substring(0, 6) : cleaned;
+        return "관리자-" + suffix;
     }
 }

--- a/src/main/java/kr/ac/knu/comit/global/auth/SsoAuthenticationFilter.java
+++ b/src/main/java/kr/ac/knu/comit/global/auth/SsoAuthenticationFilter.java
@@ -14,6 +14,7 @@ import kr.ac.knu.comit.auth.service.AuthCookieManager;
 import kr.ac.knu.comit.auth.service.ExternalIdentityMapper;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.MemberErrorCode;
+
 import kr.ac.knu.comit.member.domain.Member;
 import kr.ac.knu.comit.member.service.MemberRegistrationService;
 import kr.ac.knu.comit.member.service.MemberService;
@@ -69,15 +70,21 @@ public class SsoAuthenticationFilter extends OncePerRequestFilter {
             Optional<Member> memberOptional = memberService.findBySso(provisionalPrincipal);
             if (memberOptional.isEmpty()) {
                 if (adminEmailProperties.isAdminEmail(identity.email())) {
-                    memberRegistrationService.register(
-                            identity.ssoSub(),
-                            ADMIN_DISPLAY,
-                            ADMIN_PHONE_PLACEHOLDER,
-                            adminNickname(identity.ssoSub()),
-                            null,
-                            null,
-                            null
-                    );
+                    try {
+                        memberRegistrationService.register(
+                                identity.ssoSub(),
+                                ADMIN_DISPLAY,
+                                ADMIN_PHONE_PLACEHOLDER,
+                                adminNickname(identity.ssoSub()),
+                                null,
+                                null,
+                                null
+                        );
+                    } catch (BusinessException e) {
+                        if (e.getErrorCode() != MemberErrorCode.MEMBER_ALREADY_EXISTS) {
+                            throw e;
+                        }
+                    }
                     memberOptional = memberService.findBySso(provisionalPrincipal);
                 } else {
                     throw new BusinessException(MemberErrorCode.REGISTRATION_REQUIRED);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,7 @@ comit:
       enabled: ${COMIT_DEV_AUTH_ENABLED:false}
       cookie-same-site: ${COMIT_DEV_AUTH_COOKIE_SAME_SITE:None}
   auth:
+    admin-emails: ${COMIT_AUTH_ADMIN_EMAILS:}
     bridge:
       enabled: ${COMIT_AUTH_BRIDGE_ENABLED:false}
     sso:

--- a/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
@@ -124,6 +124,12 @@ class AuthenticatedApiWebTest {
     @MockitoBean
     private MemberRepository memberRepository;
 
+    @MockitoBean
+    private kr.ac.knu.comit.auth.config.AdminEmailProperties adminEmailProperties;
+
+    @MockitoBean
+    private kr.ac.knu.comit.member.service.MemberRegistrationService memberRegistrationService;
+
     @BeforeEach
     void setUp() {
         given(memberService.findBySso(any())).willReturn(Optional.of(authenticatedMember()));

--- a/src/test/java/kr/ac/knu/comit/api/SsoAuthWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/SsoAuthWebTest.java
@@ -52,6 +52,7 @@ import org.springframework.test.web.servlet.MvcResult;
         GlobalExceptionHandler.class,
         ComitSsoProperties.class,
         AuthCookieManager.class,
+        kr.ac.knu.comit.auth.config.AdminEmailProperties.class,
         ExternalIdentityMapper.class,
         RegisterService.class,
         SsoAuthService.class,

--- a/src/test/java/kr/ac/knu/comit/auth/service/SsoAuthServiceTest.java
+++ b/src/test/java/kr/ac/knu/comit/auth/service/SsoAuthServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.lenient;
 
 import java.util.List;
+import kr.ac.knu.comit.auth.config.AdminEmailProperties;
 import kr.ac.knu.comit.auth.config.ComitSsoProperties;
 import kr.ac.knu.comit.auth.dto.SsoCallbackPendingRegistration;
 import kr.ac.knu.comit.auth.dto.SsoCallbackRejected;
@@ -18,6 +19,7 @@ import kr.ac.knu.comit.auth.port.ExternalIdentity;
 import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.global.exception.BusinessException;
 import kr.ac.knu.comit.global.exception.CommonErrorCode;
+import kr.ac.knu.comit.member.service.MemberRegistrationService;
 import kr.ac.knu.comit.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,6 +38,8 @@ class SsoAuthServiceTest {
     @Mock private AuthCookieManager authCookieManager;
     @Mock private ExternalIdentityMapper externalIdentityMapper;
     @Mock private MemberService memberService;
+    @Mock private MemberRegistrationService memberRegistrationService;
+    @Mock private AdminEmailProperties adminEmailProperties;
     @InjectMocks private SsoAuthService ssoAuthService;
 
     @Nested


### PR DESCRIPTION
# Feat/#76 admin 접속 분기 구현
- resolves #76 

## 배경 및 필요성

기존에는 역할(Role) 정보가 SSO 토큰 또는 API Gateway 헤더에서만 전달되어, **서버 자체적으로 관리자를 지정할 수 없는 구조**였다.
이를 해결하기 위해 환경변수로 관리자 이메일 목록을 등록하고, 해당 이메일로 인증 시 자동으로 ADMIN 권한을 부여하고 회원가입까지 처리하는 기능을 추가한다.

---

## 목적

- 환경변수(`COMIT_AUTH_ADMIN_EMAILS`)로 관리자 이메일을 유연하게 관리
- 관리자 이메일 보유자가 최초 로그인 시 별도 회원가입 절차 없이 자동 등록
- 이후 요청부터 ADMIN 권한으로 모든 API 이용 가능

---

## 변경 사항

### 신규 파일

**`AdminEmailProperties.java`**
- `comit.auth.admin-emails` 프로퍼티를 `List<String>`으로 바인딩
- 환경변수: `COMIT_AUTH_ADMIN_EMAILS=admin@knu.ac.kr,super@knu.ac.kr`
- 대소문자·공백 무시하여 이메일 포함 여부 판단하는 `isAdminEmail()` 제공

---

### 변경 파일

**`ExternalIdentityMapper`**
- `toPrincipal()` 진입 시 다른 필드 검증보다 먼저 이메일을 확인
- 관리자 이메일이면 `name`, `email` 필드를 `"관리자"`로 설정하고 `role=ADMIN`으로 principal 생성

**`SsoAuthService`**
- `handleCallback()` 에서 미가입 사용자 분기 시 관리자 이메일이면 자동 회원가입 후 success 반환
- 일반 사용자는 기존과 동일하게 회원가입 페이지로 리다이렉트

**`SsoAuthenticationFilter`**
- SSO 토큰 검증 후 관리자 이메일 미가입 상태이면 자동 회원가입 처리
- `MEMBER_ALREADY_EXISTS` 예외는 무시하여 동시 요청으로 인한 중복 등록 방어

**`MemberAuthenticationFilter`**
- Bridge 환경에서도 동일하게 관리자 이메일 자동 회원가입 처리
- `MEMBER_ALREADY_EXISTS` 예외 무시로 race condition 방어

**`application.yml`**
```yaml
comit:
  auth:
    admin-emails: ${COMIT_AUTH_ADMIN_EMAILS:}
```

---

## 인증 흐름

```
로그인 요청
  └─ email이 adminEmails에 포함?
       ├─ YES → DB에 회원 없으면 자동 회원가입 (nickname="관리자-{ssoSub앞6자}")
       │         → principal: name="관리자", email="관리자", role=ADMIN
       │         → 모든 API 정상 이용 가능
       └─ NO  → 기존 흐름 유지 (미가입 시 회원가입 페이지 이동)
```

---

## 동시성 처리

관리자 이메일로 동시에 두 요청이 들어올 경우 `MemberRegistrationService`가 ssoSub 충돌을 `MEMBER_ALREADY_EXISTS`로 변환한다.
이를 각 필터·서비스에서 catch하여 무시하고 이후 DB 조회를 정상 진행한다.

```java
try {
    memberRegistrationService.register(...);
} catch (BusinessException e) {
    if (e.getErrorCode() != MemberErrorCode.MEMBER_ALREADY_EXISTS) {
        throw e;
    }
    // 동시 요청으로 이미 등록된 경우 → 무시하고 계속
}
```

---

## 테스트

- 기존 158개 테스트 전체 통과
- `SsoAuthServiceTest`: `AdminEmailProperties`, `MemberRegistrationService` mock 추가
- `AuthenticatedApiWebTest`: 동일 mock 추가
- `SsoAuthWebTest`: `AdminEmailProperties` `@Import` 추가
