### PR TITLE
feat(member): /members/me 응답에 role 필드 추가

### DIFF
--- a/docs/api/member/MemberControllerApi.html
+++ b/docs/api/member/MemberControllerApi.html
@@ -307,6 +307,12 @@
     <td>-</td>
 </tr>
 <tr>
+    <td><code>role</code></td>
+    <td><span class="type-chip type-custom">MemberRole</span></td>
+    <td><span class="badge-optional">optional</span></td>
+    <td>-</td>
+</tr>
+<tr>
     <td><code>studentNumber</code></td>
     <td><span class="type-chip type-string">String</span></td>
     <td><span class="badge-optional">optional</span></td>

--- a/src/main/java/kr/ac/knu/comit/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/knu/comit/member/controller/MemberController.java
@@ -19,7 +19,7 @@ public class MemberController implements MemberControllerApi {
 
     @Override
     public ResponseEntity<ApiResponse<MemberProfileResponse>> getMyProfile(MemberPrincipal principal) {
-        return ResponseEntity.ok(ApiResponse.success(memberService.getMyProfile(principal.memberId())));
+        return ResponseEntity.ok(ApiResponse.success(memberService.getMyProfile(principal.memberId(), principal.role())));
     }
 
     @Override

--- a/src/main/java/kr/ac/knu/comit/member/dto/MemberProfileResponse.java
+++ b/src/main/java/kr/ac/knu/comit/member/dto/MemberProfileResponse.java
@@ -1,5 +1,6 @@
 package kr.ac.knu.comit.member.dto;
 
+import kr.ac.knu.comit.global.auth.MemberPrincipal;
 import kr.ac.knu.comit.member.domain.Member;
 
 public record MemberProfileResponse(
@@ -8,16 +9,18 @@ public record MemberProfileResponse(
         String studentNumber,
         boolean studentNumberVisible,
         String profileImageUrl,
-        String majorTrack
+        String majorTrack,
+        MemberPrincipal.MemberRole role
 ) {
-    public static MemberProfileResponse from(Member member) {
+    public static MemberProfileResponse from(Member member, MemberPrincipal.MemberRole role) {
         return new MemberProfileResponse(
                 member.getId(),
                 member.getNickname(),
                 member.getStudentNumber(),
                 member.isStudentNumberVisible(),
                 member.getProfileImageUrl(),
-                member.getMajorTrack()
+                member.getMajorTrack(),
+                role
         );
     }
 }

--- a/src/main/java/kr/ac/knu/comit/member/service/MemberService.java
+++ b/src/main/java/kr/ac/knu/comit/member/service/MemberService.java
@@ -21,8 +21,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    public MemberProfileResponse getMyProfile(Long memberId) {
-        return MemberProfileResponse.from(findMemberOrThrow(memberId));
+    public MemberProfileResponse getMyProfile(Long memberId, MemberPrincipal.MemberRole role) {
+        return MemberProfileResponse.from(findMemberOrThrow(memberId), role);
     }
 
     @Transactional


### PR DESCRIPTION
## Summary

- `MemberProfileResponse`에 `role: MemberRole` 필드 추가
- `MemberService.getMyProfile()`에 `role` 파라미터 추가
- `MemberController`에서 `principal.role()` 전달

role은 SSO JWT 클레임(`role`)에서 파싱된 `MemberPrincipal`에서 가져오며, `Member` 엔티티에는 저장하지 않는다.

## Test plan

- [ ] `GET /members/me` 응답에 `role` 필드 포함 확인
- [ ] ADMIN 계정으로 로그인 시 `role: "ADMIN"` 반환 확인
- [ ] 일반 사용자 로그인 시 `role: "STUDENT"` 반환 확인

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User profile data now includes role information when retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->