### PR TITLE
feat(member): Comit 자체 관리자 Role 도입 (DB 기반)

### DIFF
--- a/docs/api/member/MemberControllerApi.html
+++ b/docs/api/member/MemberControllerApi.html
@@ -308,7 +308,7 @@
 </tr>
 <tr>
     <td><code>role</code></td>
-    <td><span class="type-chip type-custom">MemberRole</span></td>
+    <td><span class="type-chip type-custom">ComitRole</span></td>
     <td><span class="badge-optional">optional</span></td>
     <td>-</td>
 </tr>

--- a/src/main/java/kr/ac/knu/comit/auth/service/ExternalIdentityMapper.java
+++ b/src/main/java/kr/ac/knu/comit/auth/service/ExternalIdentityMapper.java
@@ -21,7 +21,7 @@ public class ExternalIdentityMapper {
                 requiredString(identity.email()),
                 identity.studentNumber(),
                 parseUserType(identity.userType()),
-                parseRole(identity.role())
+                MemberPrincipal.MemberRole.STUDENT  // SSO role 무시, Comit role은 DB에서 관리
         );
     }
 
@@ -31,15 +31,6 @@ public class ExternalIdentityMapper {
         } catch (IllegalArgumentException exception) {
             throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
         }
-    }
-
-    private MemberPrincipal.MemberRole parseRole(String rawValue) {
-        if (rawValue == null || rawValue.isBlank()) {
-            return MemberPrincipal.MemberRole.STUDENT;
-        }
-        return "ADMIN".equalsIgnoreCase(rawValue)
-                ? MemberPrincipal.MemberRole.ADMIN
-                : MemberPrincipal.MemberRole.STUDENT;
     }
 
     private String requiredString(String value) {

--- a/src/main/java/kr/ac/knu/comit/global/auth/DevAuthFilter.java
+++ b/src/main/java/kr/ac/knu/comit/global/auth/DevAuthFilter.java
@@ -49,11 +49,11 @@ public class DevAuthFilter extends OncePerRequestFilter {
         try {
             String[] parts = cookieValue.split("\\|", 2);
             String ssoSub = parts[0];
-            MemberPrincipal.MemberRole role = parts.length > 1
-                    ? parseRole(parts[1])
-                    : MemberPrincipal.MemberRole.STUDENT;
 
             memberRepository.findBySsoSubAndDeletedAtIsNull(ssoSub).ifPresent(member -> {
+                MemberPrincipal.MemberRole memberRole = member.getComitRole() == kr.ac.knu.comit.member.domain.ComitRole.ADMIN
+                        ? MemberPrincipal.MemberRole.ADMIN
+                        : MemberPrincipal.MemberRole.STUDENT;
                 MemberPrincipal principal = new MemberPrincipal(
                         member.getId(),
                         member.getSsoSub(),
@@ -61,7 +61,7 @@ public class DevAuthFilter extends OncePerRequestFilter {
                         null,
                         member.getStudentNumber(),
                         MemberPrincipal.UserType.CSE_STUDENT,
-                        role
+                        memberRole
                 );
                 request.setAttribute(MemberArgumentResolver.PRINCIPAL_ATTRIBUTE, principal);
             });
@@ -97,11 +97,4 @@ public class DevAuthFilter extends OncePerRequestFilter {
         return null;
     }
 
-    private MemberPrincipal.MemberRole parseRole(String value) {
-        try {
-            return MemberPrincipal.MemberRole.valueOf(value.toUpperCase());
-        } catch (IllegalArgumentException ignored) {
-            return MemberPrincipal.MemberRole.STUDENT;
-        }
-    }
 }

--- a/src/main/java/kr/ac/knu/comit/global/auth/MemberAuthenticationFilter.java
+++ b/src/main/java/kr/ac/knu/comit/global/auth/MemberAuthenticationFilter.java
@@ -78,7 +78,7 @@ public class MemberAuthenticationFilter extends OncePerRequestFilter {
                     provisionalPrincipal.email(),
                     provisionalPrincipal.studentNumber(),
                     provisionalPrincipal.userType(),
-                    provisionalPrincipal.role()
+                    toMemberRole(member.getComitRole())
             );
 
             request.setAttribute(MemberArgumentResolver.PRINCIPAL_ATTRIBUTE, authenticatedPrincipal);
@@ -107,6 +107,12 @@ public class MemberAuthenticationFilter extends OncePerRequestFilter {
 
     private MemberPrincipal.UserType parseUserType(String rawValue) {
         return parseEnum(rawValue, MemberPrincipal.UserType.CSE_STUDENT, MemberPrincipal.UserType.class);
+    }
+
+    private MemberPrincipal.MemberRole toMemberRole(kr.ac.knu.comit.member.domain.ComitRole comitRole) {
+        return comitRole == kr.ac.knu.comit.member.domain.ComitRole.ADMIN
+                ? MemberPrincipal.MemberRole.ADMIN
+                : MemberPrincipal.MemberRole.STUDENT;
     }
 
     private MemberPrincipal.MemberRole parseRole(String rawValue) {

--- a/src/main/java/kr/ac/knu/comit/member/controller/MemberController.java
+++ b/src/main/java/kr/ac/knu/comit/member/controller/MemberController.java
@@ -19,7 +19,7 @@ public class MemberController implements MemberControllerApi {
 
     @Override
     public ResponseEntity<ApiResponse<MemberProfileResponse>> getMyProfile(MemberPrincipal principal) {
-        return ResponseEntity.ok(ApiResponse.success(memberService.getMyProfile(principal.memberId(), principal.role())));
+        return ResponseEntity.ok(ApiResponse.success(memberService.getMyProfile(principal.memberId())));
     }
 
     @Override

--- a/src/main/java/kr/ac/knu/comit/member/domain/ComitRole.java
+++ b/src/main/java/kr/ac/knu/comit/member/domain/ComitRole.java
@@ -1,0 +1,5 @@
+package kr.ac.knu.comit.member.domain;
+
+public enum ComitRole {
+    ADMIN, STUDENT
+}

--- a/src/main/java/kr/ac/knu/comit/member/domain/Member.java
+++ b/src/main/java/kr/ac/knu/comit/member/domain/Member.java
@@ -48,6 +48,10 @@ public class Member {
     @Column(nullable = false, length = 20)
     private MemberStatus status = MemberStatus.ACTIVE;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ComitRole comitRole = ComitRole.STUDENT;
+
     private LocalDateTime suspendedUntil;
 
     @Column(nullable = false, updatable = false)
@@ -200,6 +204,18 @@ public class Member {
 
     public MemberStatus getStatus() {
         return status;
+    }
+
+    public ComitRole getComitRole() {
+        return comitRole;
+    }
+
+    public void promoteToAdmin() {
+        this.comitRole = ComitRole.ADMIN;
+    }
+
+    public void demoteToStudent() {
+        this.comitRole = ComitRole.STUDENT;
     }
 
     public LocalDateTime getSuspendedUntil() {

--- a/src/main/java/kr/ac/knu/comit/member/dto/MemberProfileResponse.java
+++ b/src/main/java/kr/ac/knu/comit/member/dto/MemberProfileResponse.java
@@ -1,6 +1,6 @@
 package kr.ac.knu.comit.member.dto;
 
-import kr.ac.knu.comit.global.auth.MemberPrincipal;
+import kr.ac.knu.comit.member.domain.ComitRole;
 import kr.ac.knu.comit.member.domain.Member;
 
 public record MemberProfileResponse(
@@ -10,9 +10,9 @@ public record MemberProfileResponse(
         boolean studentNumberVisible,
         String profileImageUrl,
         String majorTrack,
-        MemberPrincipal.MemberRole role
+        ComitRole role
 ) {
-    public static MemberProfileResponse from(Member member, MemberPrincipal.MemberRole role) {
+    public static MemberProfileResponse from(Member member) {
         return new MemberProfileResponse(
                 member.getId(),
                 member.getNickname(),
@@ -20,7 +20,7 @@ public record MemberProfileResponse(
                 member.isStudentNumberVisible(),
                 member.getProfileImageUrl(),
                 member.getMajorTrack(),
-                role
+                member.getComitRole()
         );
     }
 }

--- a/src/main/java/kr/ac/knu/comit/member/service/MemberService.java
+++ b/src/main/java/kr/ac/knu/comit/member/service/MemberService.java
@@ -21,8 +21,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    public MemberProfileResponse getMyProfile(Long memberId, MemberPrincipal.MemberRole role) {
-        return MemberProfileResponse.from(findMemberOrThrow(memberId), role);
+    public MemberProfileResponse getMyProfile(Long memberId) {
+        return MemberProfileResponse.from(findMemberOrThrow(memberId));
     }
 
     @Transactional

--- a/src/main/resources/db/migration/V13__add_comit_role_to_member.sql
+++ b/src/main/resources/db/migration/V13__add_comit_role_to_member.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member
+    ADD COLUMN comit_role VARCHAR(20) NOT NULL DEFAULT 'STUDENT' AFTER status;

--- a/src/main/resources/db/seed/V100__dev_seed.sql
+++ b/src/main/resources/db/seed/V100__dev_seed.sql
@@ -2,8 +2,8 @@
 -- 이 파일은 application-local.yml / application-staging.yml 의 flyway.locations 에만 포함됩니다.
 -- prod 환경에 절대 포함하지 마세요.
 
-INSERT IGNORE INTO member (sso_sub, nickname, name, phone, student_number, major_track, student_number_visible, status, created_at, agreed_at)
+INSERT IGNORE INTO member (sso_sub, nickname, name, phone, student_number, major_track, student_number_visible, status, comit_role, created_at, agreed_at)
 VALUES
-    ('dev-admin-001', '관리자', '관리자', '010-0000-0000', '2020000001', null, true, 'ACTIVE', NOW(), NOW()),
-    ('dev-user-001',  '일반유저', '김철수', '010-0000-0001', '2021000001', null, true, 'ACTIVE', NOW(), NOW()),
-    ('dev-user-002',  '테스트유저', '이영희', '010-0000-0002', '2022000001', null, true, 'ACTIVE', NOW(), NOW());
+    ('dev-admin-001', '관리자', '관리자', '010-0000-0000', '2020000001', null, true, 'ACTIVE', 'ADMIN', NOW(), NOW()),
+    ('dev-user-001',  '일반유저', '김철수', '010-0000-0001', '2021000001', null, true, 'ACTIVE', 'STUDENT', NOW(), NOW()),
+    ('dev-user-002',  '테스트유저', '이영희', '010-0000-0002', '2022000001', null, true, 'ACTIVE', 'STUDENT', NOW(), NOW());

--- a/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
@@ -511,6 +511,19 @@ class AuthenticatedApiWebTest {
     }
 
     @Test
+    void returnsForbiddenWhenHeaderSaysAdminButDbRoleIsStudent() throws Exception {
+        // when & then
+        // 헤더 role이 ADMIN이어도 DB role이 STUDENT면 관리자 API 접근은 거부되어야 한다.
+        mockMvc.perform(get("/admin/reports")
+                        .header("X-Member-Sub", "member-1")
+                        .header("X-Member-Name", "student")
+                        .header("X-Member-Role", "ADMIN"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.type").value("/problems/common/forbidden"))
+                .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"));
+    }
+
+    @Test
     void returnsForbiddenWhenNonAdminRequestsAdminMemberList() throws Exception {
         // when & then
         // 관리자 권한이 아니면 회원 관리자 API 접근이 거부되어야 한다.

--- a/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/AuthenticatedApiWebTest.java
@@ -35,6 +35,7 @@ import kr.ac.knu.comit.main.dto.MainPageResponse;
 import kr.ac.knu.comit.main.service.MainService;
 import kr.ac.knu.comit.member.controller.AdminMemberController;
 import kr.ac.knu.comit.member.controller.MemberController;
+import kr.ac.knu.comit.member.domain.ComitRole;
 import kr.ac.knu.comit.member.domain.Member;
 import kr.ac.knu.comit.member.domain.MemberRepository;
 import kr.ac.knu.comit.member.service.AdminMemberService;
@@ -135,7 +136,7 @@ class AuthenticatedApiWebTest {
         // given
         // 인증된 사용자의 프로필 응답을 준비한다.
         given(memberService.getMyProfile(1L))
-                .willReturn(new MemberProfileResponse(1L, "comit-user", "2020111111", true, null, null));
+                .willReturn(new MemberProfileResponse(1L, "comit-user", "2020111111", true, null, null, ComitRole.STUDENT));
 
         // when & then
         // 인증 헤더가 컨트롤러까지 주입되고 응답이 정상 직렬화되는지 확인한다.
@@ -462,6 +463,7 @@ class AuthenticatedApiWebTest {
     @Test
     void mapsAdminReportListResponseForAdmin() throws Exception {
         // given
+        given(memberService.findBySso(any())).willReturn(Optional.of(adminMember()));
         // 관리자 신고 목록 응답을 준비한다.
         given(adminReportService.getReports(eq(null), eq(null), any(org.springframework.data.domain.Pageable.class)))
                 .willReturn(new AdminReportPageResponse(
@@ -595,6 +597,7 @@ class AuthenticatedApiWebTest {
     @Test
     void returnsBadRequestWhenAdminMemberStatusBodyOmitsStatus() throws Exception {
         // given
+        given(memberService.findBySso(any())).willReturn(Optional.of(adminMember()));
         // 실제 회원 조회까지 도달하도록 관리자 대상 회원을 준비한다.
         given(memberRepository.findByIdAndDeletedAtIsNull(1L))
                 .willReturn(Optional.of(authenticatedMember()));
@@ -619,6 +622,7 @@ class AuthenticatedApiWebTest {
     @Test
     void deletesMemberWhenAdminRequestsAdminMemberDelete() throws Exception {
         // given
+        given(memberService.findBySso(any())).willReturn(Optional.of(adminMember()));
         // 실제 회원 조회까지 도달하도록 관리자 대상 회원을 준비한다.
         given(memberRepository.findByIdAndDeletedAtIsNull(1L))
                 .willReturn(Optional.of(authenticatedMember()));
@@ -635,6 +639,7 @@ class AuthenticatedApiWebTest {
 
     @Test
     void returnsAdminPostDetailWhenAdminRequestsIt() throws Exception {
+        given(memberService.findBySso(any())).willReturn(Optional.of(adminMember()));
         given(adminPostService.getPost(42L)).willReturn(
                 new AdminPostDetailResponse(
                         42L,
@@ -665,6 +670,7 @@ class AuthenticatedApiWebTest {
 
     @Test
     void updatesAdminPostWhenAdminRequestsIt() throws Exception {
+        given(memberService.findBySso(any())).willReturn(Optional.of(adminMember()));
         mockMvc.perform(patch("/admin/posts/42")
                         .header("X-Member-Sub", "member-1")
                         .header("X-Member-Name", "admin")
@@ -686,6 +692,7 @@ class AuthenticatedApiWebTest {
     @Test
     void returnsNotFoundWhenAdminRequestsMissingAdminMemberDelete() throws Exception {
         // given
+        given(memberService.findBySso(any())).willReturn(Optional.of(adminMember()));
         // 삭제 대상 회원이 존재하지 않는 상황을 준비한다.
         given(memberRepository.findByIdAndDeletedAtIsNull(99L)).willReturn(Optional.empty());
 
@@ -703,6 +710,7 @@ class AuthenticatedApiWebTest {
     @Test
     void returnsBadRequestWhenAdminRequestsReceivedTransitionForReportReview() throws Exception {
         // given
+        given(memberService.findBySso(any())).willReturn(Optional.of(adminMember()));
         // RECEIVED로의 자기 전이를 요청하면 INVALID_REQUEST를 반환하도록 준비한다.
         willThrow(new BusinessException(CommonErrorCode.INVALID_REQUEST))
                 .given(adminReportService)
@@ -918,6 +926,22 @@ class AuthenticatedApiWebTest {
                 LocalDateTime.now()
         );
         ReflectionTestUtils.setField(member, "id", 1L);
+        return member;
+    }
+
+    private Member adminMember() {
+        Member member = Member.create(
+                "member-1",
+                "관리자",
+                "010-0000-0000",
+                "admin-user",
+                "2020000001",
+                null,
+                null,
+                LocalDateTime.now()
+        );
+        ReflectionTestUtils.setField(member, "id", 1L);
+        ReflectionTestUtils.setField(member, "comitRole", ComitRole.ADMIN);
         return member;
     }
 }

--- a/src/test/java/kr/ac/knu/comit/api/SsoAuthWebTest.java
+++ b/src/test/java/kr/ac/knu/comit/api/SsoAuthWebTest.java
@@ -31,6 +31,7 @@ import kr.ac.knu.comit.global.exception.GlobalExceptionHandler;
 import kr.ac.knu.comit.image.dto.PresignedUploadResponse;
 import kr.ac.knu.comit.image.service.ImageService;
 import kr.ac.knu.comit.member.controller.MemberController;
+import kr.ac.knu.comit.member.domain.ComitRole;
 import kr.ac.knu.comit.member.domain.Member;
 import kr.ac.knu.comit.member.dto.MemberProfileResponse;
 import kr.ac.knu.comit.member.service.MemberRegistrationService;
@@ -106,7 +107,7 @@ class SsoAuthWebTest {
         given(memberService.hasDeletedMember("sso-sub-1")).willReturn(false);
         given(memberService.hasActiveMember("sso-sub-1")).willReturn(true);
         given(memberService.getMyProfile(1L))
-                .willReturn(new MemberProfileResponse(1L, "comit-user", "2023012780", true, null, null));
+                .willReturn(new MemberProfileResponse(1L, "comit-user", "2023012780", true, null, null, ComitRole.STUDENT));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `member` 테이블에 `comit_role` 컬럼 추가 (기본값 `STUDENT`)
- `ComitRole` enum 추가 (`ADMIN` | `STUDENT`)
- `Member` 엔티티에 `comitRole` 필드 + `promoteToAdmin()` / `demoteToStudent()` 메서드 추가
- `MemberAuthenticationFilter` / `DevAuthFilter`: SSO role 무시, DB `comitRole` 주입
- `MemberProfileResponse`: `principal.role()` → `member.getComitRole()`
- `ExternalIdentityMapper`: SSO role 파싱 제거
- 테스트: `adminMember()` fixture 추가, Admin 테스트 mock 수정

## 배경

SSO 시스템 관리자와 Comit 서비스 관리자가 독립적으로 관리되어야 함.
기존 `principal.isAdmin()`은 SSO JWT 클레임 기반이었으나, 이제 DB `comit_role` 기반으로 동작.
기존 Admin 권한 체크 코드 (`AdminPostController` 등 5곳)는 변경 없이 동작.

## Test plan

- [x] 전체 테스트 통과 (BUILD SUCCESSFUL)
- [ ] ADMIN `comit_role`을 가진 멤버만 `/admin/*` API 접근 가능 확인
- [ ] 일반 멤버는 403 반환 확인

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Role determination now comes solely from the stored member role rather than incoming SSO values.

* **Database**
  * Added a persistent role field for members with a default of STUDENT and a migration/seed update.

* **Tests**
  * Updated and added tests to reflect DB-driven role behavior, including admin-vs-student access checks.

* **Documentation**
  * API docs updated to show the new role type in the profile response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->