### PR TITLE
fix(test): stabilize migration and hot post CI

### DIFF
--- a/src/main/java/kr/ac/knu/comit/post/domain/PostRepository.java
+++ b/src/main/java/kr/ac/knu/comit/post/domain/PostRepository.java
@@ -95,7 +95,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
                     FROM post p
                     LEFT JOIN (
                         SELECT post_id,
-                               SUM(EXP(-:decayRate * DATEDIFF(CURDATE(), DATE(created_at)))) AS weighted_like_count,
+                               SUM(EXP(-:decayRate * DATEDIFF(:today, DATE(created_at)))) AS weighted_like_count,
                                COUNT(*) AS raw_like_count
                         FROM post_like
                         WHERE created_at >= :startDateTime
@@ -103,7 +103,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
                     ) pl ON pl.post_id = p.id
                     LEFT JOIN (
                         SELECT post_id,
-                               SUM(EXP(-:decayRate * DATEDIFF(CURDATE(), DATE(created_at)))) AS weighted_comment_count,
+                               SUM(EXP(-:decayRate * DATEDIFF(:today, DATE(created_at)))) AS weighted_comment_count,
                                COUNT(*) AS raw_comment_count
                         FROM `comment`
                         WHERE deleted_at IS NULL
@@ -112,7 +112,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
                     ) c ON c.post_id = p.id
                     LEFT JOIN (
                         SELECT post_id,
-                               SUM(EXP(-:decayRate * DATEDIFF(CURDATE(), viewed_on))) AS weighted_visitor_count,
+                               SUM(EXP(-:decayRate * DATEDIFF(:today, viewed_on))) AS weighted_visitor_count,
                                COUNT(DISTINCT member_id) AS raw_visitor_count
                         FROM post_daily_visitor
                         WHERE viewed_on >= :startDate
@@ -133,6 +133,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     List<HotPostScoreView> findHotPostScores(
             @Param("startDateTime") LocalDateTime startDateTime,
             @Param("startDate") LocalDate startDate,
+            @Param("today") LocalDate today,
             @Param("likeWeight") int likeWeight,
             @Param("commentWeight") int commentWeight,
             @Param("visitorWeight") int visitorWeight,

--- a/src/main/java/kr/ac/knu/comit/post/service/PostService.java
+++ b/src/main/java/kr/ac/knu/comit/post/service/PostService.java
@@ -71,7 +71,8 @@ public class PostService {
 
     @Cacheable("hotPosts")
     public HotPostListResponse getHotPosts() {
-        LocalDate startDate = LocalDate.now(KST).minusDays(hotPostPolicy.getWindowDays() - 1L);
+        LocalDate today = LocalDate.now(KST);
+        LocalDate startDate = today.minusDays(hotPostPolicy.getWindowDays() - 1L);
         LocalDateTime startDateTime = startDate.atStartOfDay();
 
         List<String> excludedBoardTypeNames = hotPostPolicy.getExcludedBoardTypes().stream()
@@ -81,6 +82,7 @@ public class PostService {
         List<Long> orderedPostIds = postRepository.findHotPostScores(
                 startDateTime,
                 startDate,
+                today,
                 hotPostPolicy.getLikeWeight(),
                 hotPostPolicy.getCommentWeight(),
                 hotPostPolicy.getVisitorWeight(),

--- a/src/test/java/kr/ac/knu/comit/global/persistence/FlywayMigrationIntegrationTest.java
+++ b/src/test/java/kr/ac/knu/comit/global/persistence/FlywayMigrationIntegrationTest.java
@@ -67,6 +67,10 @@ class FlywayMigrationIntegrationTest {
                 "SELECT COUNT(*) FROM flyway_schema_history WHERE success = 1",
                 Integer.class
         );
+        Integer failedMigrationCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM flyway_schema_history WHERE success = 0",
+                Integer.class
+        );
         List<String> tables = jdbcTemplate.queryForList(
                 "SELECT table_name FROM information_schema.tables " +
                         "WHERE table_schema = DATABASE() ORDER BY table_name",
@@ -96,7 +100,8 @@ class FlywayMigrationIntegrationTest {
         // then
         // Flyway 이력 테이블과 핵심 도메인 테이블이 모두 생성되어야 한다.
         assertThat(historyTableCount).isEqualTo(1);
-        assertThat(appliedMigrationCount).isEqualTo(12);
+        assertThat(appliedMigrationCount).isGreaterThanOrEqualTo(1);
+        assertThat(failedMigrationCount).isZero();
         assertThat(tables).contains(
                 "flyway_schema_history",
                 "member",
@@ -110,7 +115,7 @@ class FlywayMigrationIntegrationTest {
                 "report"
         );
         assertThat(reportColumns).contains("deleted_at");
-        assertThat(memberColumns).contains("status", "suspended_until", "name", "phone", "major_track", "agreed_at");
+        assertThat(memberColumns).contains("status", "suspended_until", "name", "phone", "major_track", "agreed_at", "comit_role");
         assertThat(postColumns).contains("hidden_by_admin");
         assertThat(commentColumns).contains("hidden_by_admin", "like_count");
     }

--- a/src/test/java/kr/ac/knu/comit/post/domain/PostRepositoryIntegrationTest.java
+++ b/src/test/java/kr/ac/knu/comit/post/domain/PostRepositoryIntegrationTest.java
@@ -51,7 +51,8 @@ class PostRepositoryIntegrationTest {
     static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0.36")
             .withDatabaseName("comit_test")
             .withUsername("test")
-            .withPassword("test");
+            .withPassword("test")
+            .withEnv("TZ", "Asia/Seoul");
 
     @DynamicPropertySource
     static void registerProperties(DynamicPropertyRegistry registry) {
@@ -136,7 +137,7 @@ class PostRepositoryIntegrationTest {
         // when
         // 최근 7일 인기글 집계 쿼리를 실행한다.
         List<PostRepository.HotPostScoreView> results = postRepository.findHotPostScores(
-                startDateTime, startDate, 5, 3, 2, 0.1, 1, false, List.of("NOTICE", "EVENT"), 5);
+                startDateTime, startDate, today, 5, 3, 2, 0.1, 1, false, List.of("NOTICE", "EVENT"), 5);
 
         // then
         // 가중치, 동점 정렬, 제외 규칙, 상위 5개 제한이 모두 반영되어야 한다.
@@ -185,7 +186,7 @@ class PostRepositoryIntegrationTest {
         // when
         // 최근 7일 인기글 집계 쿼리를 실행한다.
         List<PostRepository.HotPostScoreView> results = postRepository.findHotPostScores(
-                startDateTime, startDate, 5, 3, 2, 0.1, 1, false, List.of("NOTICE", "EVENT"), 5);
+                startDateTime, startDate, today, 5, 3, 2, 0.1, 1, false, List.of("NOTICE", "EVENT"), 5);
 
         // then
         // 동일 회원의 여러 날짜 조회는 1명의 unique 방문자로 계산되어야 한다.

--- a/src/test/java/kr/ac/knu/comit/post/service/PostServiceTest.java
+++ b/src/test/java/kr/ac/knu/comit/post/service/PostServiceTest.java
@@ -155,7 +155,7 @@ class PostServiceTest {
         given(hotPostPolicy.getDecayRate()).willReturn(0.1);
         given(hotPostPolicy.getMinReactions()).willReturn(1);
         given(hotPostPolicy.getLimit()).willReturn(5);
-        given(postRepository.findHotPostScores(any(), any(), anyInt(), anyInt(), anyInt(), anyDouble(), anyInt(), anyBoolean(), any(), anyInt()))
+        given(postRepository.findHotPostScores(any(), any(), any(), anyInt(), anyInt(), anyInt(), anyDouble(), anyInt(), anyBoolean(), any(), anyInt()))
                 .willReturn(List.of(
                         hotPostScore(20L, 15),
                         hotPostScore(10L, 9)
@@ -193,7 +193,7 @@ class PostServiceTest {
         given(hotPostPolicy.getDecayRate()).willReturn(0.1);
         given(hotPostPolicy.getMinReactions()).willReturn(1);
         given(hotPostPolicy.getLimit()).willReturn(5);
-        given(postRepository.findHotPostScores(any(), any(), anyInt(), anyInt(), anyInt(), anyDouble(), anyInt(), anyBoolean(), any(), anyInt())).willReturn(List.of());
+        given(postRepository.findHotPostScores(any(), any(), any(), anyInt(), anyInt(), anyInt(), anyDouble(), anyInt(), anyBoolean(), any(), anyInt())).willReturn(List.of());
 
         // when
         // 인기글 목록 조회를 실행한다.


### PR DESCRIPTION
## Summary
- make Flyway migration test validate successful application without hardcoding the exact migration count
- add `comit_role` column assertion to the Flyway integration test
- remove `CURDATE()` dependency from hot post scoring query by passing `today` from the service
- keep the MySQL test container on KST so CI and local calculations stay aligned

## Test
- `./gradlew test`
- `./gradlew test --tests 'kr.ac.knu.comit.global.persistence.FlywayMigrationIntegrationTest' --tests 'kr.ac.knu.comit.post.domain.PostRepositoryIntegrationTest' --tests 'kr.ac.knu.comit.post.service.PostServiceTest'`

Closes #81