### PR TITLE
fix: resolve flyway startup failure in staging

### DIFF
--- a/src/main/resources/db/migration/V102__add_comit_role_to_member.sql
+++ b/src/main/resources/db/migration/V102__add_comit_role_to_member.sql
@@ -1,2 +1,3 @@
 ALTER TABLE member
     ADD COLUMN comit_role VARCHAR(20) NOT NULL DEFAULT 'STUDENT' AFTER status;
+

--- a/src/main/resources/db/seed/V100__dev_seed.sql
+++ b/src/main/resources/db/seed/V100__dev_seed.sql
@@ -2,8 +2,8 @@
 -- 이 파일은 application-local.yml / application-staging.yml 의 flyway.locations 에만 포함됩니다.
 -- prod 환경에 절대 포함하지 마세요.
 
-INSERT IGNORE INTO member (sso_sub, nickname, name, phone, student_number, major_track, student_number_visible, status, comit_role, created_at, agreed_at)
+INSERT IGNORE INTO member (sso_sub, nickname, name, phone, student_number, major_track, student_number_visible, status, created_at, agreed_at)
 VALUES
-    ('dev-admin-001', '관리자', '관리자', '010-0000-0000', '2020000001', null, true, 'ACTIVE', 'ADMIN', NOW(), NOW()),
-    ('dev-user-001',  '일반유저', '김철수', '010-0000-0001', '2021000001', null, true, 'ACTIVE', 'STUDENT', NOW(), NOW()),
-    ('dev-user-002',  '테스트유저', '이영희', '010-0000-0002', '2022000001', null, true, 'ACTIVE', 'STUDENT', NOW(), NOW());
+    ('dev-admin-001', '관리자', '관리자', '010-0000-0000', '2020000001', null, true, 'ACTIVE', NOW(), NOW()),
+    ('dev-user-001',  '일반유저', '김철수', '010-0000-0001', '2021000001', null, true, 'ACTIVE', NOW(), NOW()),
+    ('dev-user-002',  '테스트유저', '이영희', '010-0000-0002', '2022000001', null, true, 'ACTIVE', NOW(), NOW());


### PR DESCRIPTION
### 관련 이슈
- resolve #85
---
## 변경 이유
- staging에서 Flyway validate 실패(`V100` checksum mismatch + `V13` ordering)로 애플리케이션 부팅이 중단됨
## 주요 변경 사항
- `src/main/resources/db/seed/V100__dev_seed.sql`
  - 이미 적용된 이력과 checksum이 맞도록 원복
- `src/main/resources/db/migration/V13__add_comit_role_to_member.sql`을 `src/main/resources/db/migration/V102__add_comit_role_to_member.sql`로 변경
  - seed 버전(`V100`,`V101`) 이후 순서로 적용되도록 migration 버전 상향
## 검증
- `./gradlew test` 통과
- `./gradlew test --tests kr.ac.knu.comit.global.persistence.FlywayMigrationIntegrationTest` 통과
## 리스크
- 공유 staging DB의 `flyway_schema_history`가 이미 손상된 경우, 배포 시 `flyway repair` 또는 DB 정합성 복구가 선행되어야 할 수 있음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added role management infrastructure for members, with 'Student' set as the default role assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->